### PR TITLE
feat(sandbox): add native hardening and OCI execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This file records notable user-facing changes.
 - Release-branch tooling for channel releases, tracked backports, signed tags, npm publication, and GitHub Releases
 - The public `@observal/axl` package, checksum-verifying installer, and CLI `--help` and `--version` output
 - Explicit `--unsafe` startup mode with separate state, logged unenforced status, and a persistent terminal warning
+- Linux Landlock and versioned seccomp enforcement with process and file resource limits
+- Digest-pinned local OCI execution through rootless Podman or Docker, including verified cleanup
+- `axl doctor` sandbox capability diagnostics
 - Dependency-free event and local wire protocols with runtime validation
 - Crash-safe JSONL sessions, branch reconstruction, redaction, and deterministic replay
 - Provider and credential contracts, thinking levels, tool dialects, a deterministic fake provider, and the built-in Azure OpenAI model catalog

--- a/NOTICE
+++ b/NOTICE
@@ -8,3 +8,9 @@ Axl uses the official Model Context Protocol TypeScript SDK as an external depen
 Axl uses Marked 18.0.11 as an external dependency for Markdown tokenization. It is distributed under its own MIT license.
 
 Axl uses grok-mermaid 0.2.2 as an external dependency for Unicode Mermaid rendering. It is distributed under its own Apache-2.0 license.
+
+Axl uses `@deepseek-ai/node-addon-landlock-run` 0.1.1 from DeepSeek Harness.
+Its JavaScript package includes an MIT notice, and its platform launcher packages
+are distributed under BSD-3-Clause. Those notices remain in the installed dependency
+packages. Axl invokes the launcher as an external process and does not copy or modify
+its source.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 Axl, short for Axolotl, is an agent harness that works with existing tools, models, and client setups. A single daemon owns each session, while terminal and future clients render the same event stream.
 
-**Current status:** phases 0 through 4 of the [technical implementation roadmap](ROADMAP.md#technical-implementation-roadmap) are complete. The TUI, Agent Skills, and MCP support were brought forward from later phases. Other later-phase work has not started.
+**Current status:** phases 0 through 4 of the [technical implementation roadmap](ROADMAP.md#technical-implementation-roadmap) are complete. The TUI, Agent Skills, MCP support, native Linux hardening, and local OCI execution were brought forward from later phases. Other later-phase work has not started.
 
 ## Install
 
-Axl requires Node.js `^22.19.0` or `>=24`. Sandboxed command execution requires Bubblewrap on Linux. macOS uses Seatbelt.
+Axl requires Node.js `^22.19.0` or `>=24`. Native sandboxed execution requires Bubblewrap on Linux; Axl installs its pinned Landlock launcher dependency. macOS uses Seatbelt. Local OCI execution optionally uses rootless Podman or Docker with seccomp and cgroups v2.
 
 Install the package from npm:
 
@@ -45,11 +45,24 @@ The `axl` command connects to the local daemon and starts one in the background 
 axl <session-id>
 axl --cwd ~/code/project
 axl daemon
+axl doctor
 ```
 
 The TUI supports multiline editing, model and theme selection, queued prompts, compact tool output, session metrics, and terminal scrollback. Run `/help` for commands and keys. Run `/quit` to detach without stopping the session.
 
-Axl will not run shell tools when the required sandbox is unavailable. To opt out explicitly, start a separate unsafe daemon and session with:
+Axl will not run shell tools when the required sandbox is unavailable. On Linux, the native provider requires working Bubblewrap, Landlock, and the versioned Axl seccomp policy. `axl doctor` reports the controls available on the host.
+
+To use a local OCI sandbox, first pull an image and pass its immutable digest:
+
+```bash
+podman pull docker.io/library/bash:5.2.37
+axl --sandbox podman \
+  --image docker.io/library/bash@sha256:<64-hex-digest>
+```
+
+Replace `podman` with `docker` to use the Docker adapter. Axl never pulls implicitly and rejects mutable image tags.
+
+To opt out explicitly, start a separate unsafe daemon and session with:
 
 ```bash
 axl --unsafe

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1961,13 +1961,13 @@ The terminal presentation surface already has first-party renderer consumers and
 
 #### OS sandbox providers
 
-- [ ] Complete Linux Bubblewrap support.
-- [ ] Add Landlock capability detection and enforcement where available.
-- [ ] Add seccomp filters and report their version.
-- [ ] Add macOS Seatbelt support.
+- [x] Complete Linux Bubblewrap support.
+- [x] Add Landlock capability detection and enforcement where available.
+- [x] Add seccomp filters and report their version.
+- [x] Add macOS Seatbelt support.
 - [ ] Add Windows restricted-token, job-object, and ACL support, with WSL2 as the stronger documented path.
-- [ ] Report the exact controls each provider can enforce.
-- [ ] Fail session startup when required controls are unavailable.
+- [x] Report the exact controls each provider can enforce.
+- [x] Fail session startup when required controls are unavailable.
 
 #### Full policy controls
 
@@ -1981,19 +1981,20 @@ The terminal presentation surface already has first-party renderer consumers and
 #### Extension isolation hardening
 
 - [ ] Add resource limits and lifecycle supervision to the Phase 6 extension process host.
+- [x] Apply resource limits and lifecycle cleanup to existing sandboxed stdio MCP processes.
 - [ ] Verify that extension processes cannot bypass filesystem, network, or credential policy through host APIs.
 - [ ] Keep trusted in-process execution limited to first-party extensions throughout v1.
 
 #### OCI runtime
 
-- [ ] Detect Podman, Docker, and containerd/nerdctl rather than requiring one engine.
-- [ ] Prefer rootless execution and report rootful operation.
+- [ ] Detect Podman, Docker, and containerd/nerdctl rather than requiring one engine. Podman and Docker are implemented; containerd/nerdctl remains.
+- [x] Prefer rootless execution and report rootful operation.
 - [ ] Support runc, crun, and youki capabilities.
 - [ ] Report stronger gVisor and Kata isolation where installed.
 - [ ] Implement create, workspace upload, start, attach, snapshot, stop, terminate, and termination verification.
 - [ ] Generate runtime-spec configuration with read-only root, dropped capabilities, no-new-privileges, seccomp, masked paths, user namespaces, no devices, and cgroups v2 limits.
 - [ ] Make termination idempotent and verifiable.
-- [ ] Resolve images to platform-specific digests.
+- [ ] Resolve images to platform-specific digests. Local OCI execution currently requires the user to supply a digest-pinned image.
 - [ ] Add signature, SBOM, and attestation verification policy.
 - [ ] Use existing registry credential helpers without exposing credentials.
 - [ ] Make offline cache behavior explicit.
@@ -2011,7 +2012,7 @@ The terminal presentation surface already has first-party renderer consumers and
 
 #### Doctor
 
-- [ ] Report detected runtimes, sandbox controls, rootless support, cgroups, missing binaries, credentials needing setup, elevated extensions, and policy mismatches.
+- [ ] Complete `/doctor` coverage for credentials, elevated extensions, and policy mismatches. Runtime, sandbox-control, rootless, cgroup, and missing-binary reporting is implemented.
 
 #### Exit gate
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -49,6 +49,39 @@ axl <session-id>
 
 The client uses `~/.axl/axl.sock`. It starts a detached local daemon when one is not already running. Use `axl daemon` to keep the daemon in the foreground for troubleshooting. Restart an existing daemon after changing exported environment variables because a running process cannot inherit later shell changes.
 
+Inspect local sandbox support without configuring provider credentials:
+
+```bash
+axl doctor
+```
+
+On Linux, native execution requires Bubblewrap plus the pinned Landlock launcher installed with Axl. Axl applies its versioned seccomp policy and fails startup when Bubblewrap, Landlock, or seccomp cannot be enforced.
+
+On Ubuntu, install the local container prerequisites with:
+
+```bash
+sudo apt-get install podman uidmap slirp4netns fuse-overlayfs crun
+```
+
+For OCI execution, use rootless Podman or a Docker engine with seccomp and cgroups v2. Pull the selected image explicitly, record its digest, and start Axl with the digest-pinned reference:
+
+```bash
+podman pull docker.io/library/bash:5.2.37
+podman image inspect docker.io/library/bash:5.2.37 --format '{{.Digest}}'
+
+axl --sandbox podman \
+  --image docker.io/library/bash@sha256:<64-hex-digest>
+```
+
+Docker uses the same contract:
+
+```bash
+axl --sandbox docker \
+  --image docker.io/library/bash@sha256:<64-hex-digest>
+```
+
+Axl never pulls an OCI image implicitly. Podman must be rootless. Docker privilege and VM isolation are reported by `axl doctor` and recorded in each session. Prefer rootless Docker or Docker Desktop's VM-backed engine. Access to a rootful Linux Docker socket is root-equivalent host authority for the trusted Axl daemon, even though the tool container remains restricted. OCI sessions use separate state directories keyed by engine and image digest.
+
 ## Global and project configuration
 
 Axl reads global configuration from `~/.axl`:

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -17,6 +17,8 @@ These decisions set the package and compatibility boundaries established during 
 
 Other packages use the kernel through public exports. Extensions cannot import private kernel paths.
 
+Linux filesystem confinement uses `@deepseek-ai/node-addon-landlock-run` 0.1.1 from <https://github.com/deepseek-harness/deepseek-harness>. Axl uses its published JavaScript API and unmodified platform launcher as a dependency. The reviewed entry tarball SHA-256 was `02c123a4eb4acedfd386fe06192dcf05e7fbb96e2845de9e2958efee4b4f0b92`. The Linux x64 platform tarball was `392e5ee27297117a058728f3a938a5b5b3302c16b423ee2a2f2dbdf612a6c0a9`, containing launcher SHA-256 `a752bc72f111fcc573c3e61fb90fa544541dac0ca498d2e279e1630d7c659b31`. The Linux arm64 platform tarball was `ecbbe99368422ac4f28a0bcf8dc3e4cb8c0a24086fb9b73cc21e77433d5d5dc8`, containing launcher SHA-256 `f6ae2ad5893e3123f45329ade5518b33c3ac3b102978001ff1c6a6a8ebe2ad9b`. The entry tarball includes an MIT notice while its package metadata declares BSD-3-Clause; the platform packages include BSD-3-Clause. Axl retains the dependency notices and does not copy or modify launcher source.
+
 These rules are stricter than the external architecture inspected for Phase 0. DSH at `cd5ef8148158c3a752a658978873241fdf8e2bbc` builds its loop from several workspace packages and uses Schemastery at runtime. Axl treats it as a read-only behavioral reference, not as a package-layout template.
 
 ## Event identity

--- a/docs/architecture/rfcs/0001-local-sandbox-backends.md
+++ b/docs/architecture/rfcs/0001-local-sandbox-backends.md
@@ -1,0 +1,79 @@
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# RFC 0001: Native and OCI local sandbox backends
+
+Status: implemented
+
+## Problem
+
+Axl's Linux sandbox used Bubblewrap namespaces and mounts, but its read-only host root still exposed files that Unix permissions allowed. It did not apply a project-owned seccomp policy or resource limits. Axl also had no local OCI execution option for users who require a container boundary or an image-defined toolchain.
+
+The terminal package previously assembled the daemon and sandbox, which made another execution backend a presentation concern. That assembly now belongs to `packages/runtime`.
+
+## Decision
+
+Axl keeps canonical tools independent of execution placement. The local runtime selects one of these backends before constructing a session:
+
+- Native Linux: Bubblewrap, Landlock, seccomp, dropped capabilities, private runtime directories, and rlimits.
+- Native macOS: Seatbelt.
+- OCI: Podman or Docker with a digest-pinned image and a shared hardened argument contract.
+- Explicit unsafe execution: no operating-system enforcement.
+
+The CLI selects OCI with `--sandbox podman|docker --image <digest-reference>`. Native execution remains the default. Unsafe execution cannot be combined with OCI selection. Each OCI engine and image digest receives separate daemon state, and clients reject a daemon whose provider or image differs from the request.
+
+## Linux native enforcement
+
+Bubblewrap establishes mount, PID, IPC, UTS, network, and user namespaces. It masks the host home and runtime directories, rebinds the workspace read/write, and rebinds additional readable roots read-only.
+
+Inside that namespace, the pinned `landlock-run` launcher applies filesystem rules before executing the command. Axl functionally probes both ordinary access and truncate mediation. A kernel that cannot enforce the required filesystem operations makes the native provider unavailable.
+
+Axl writes a versioned classic-BPF seccomp policy to a private per-user directory and passes it to Bubblewrap through an inherited descriptor. The policy denies high-risk kernel, namespace, module, keyring, tracing, and asynchronous-I/O system calls. It is a denylist, not a complete syscall allowlist.
+
+`prlimit` bounds address space, CPU time, process count, output file size, and open descriptors. Long-lived MCP processes omit the CPU-time limit but retain the other limits. Process groups provide cancellation and forced termination.
+
+## OCI enforcement
+
+OCI images must be supplied by immutable SHA-256 digest and must already exist in the selected engine. Axl never pulls an image implicitly.
+
+Podman must report rootless operation. Docker may report rootless, Docker Desktop VM isolation, or rootful operation. Rootful Docker is visible in the canonical sandbox details and gives the trusted Axl daemon root-equivalent control through the Docker socket.
+
+Every OCI command uses:
+
+- Read-only image root
+- Workspace-only persistent writes
+- Additional readable roots mounted read-only
+- Protected paths replaced by private tmpfs mounts
+- Private temporary storage
+- No network
+- No published ports or devices
+- All capabilities dropped
+- `no-new-privileges`
+- Engine seccomp
+- Cgroups v2 CPU, memory, and PID limits
+- File-size and descriptor rlimits
+- Numeric host user identity
+- A unique container name
+- Remove-on-exit plus an idempotent removal and absence check
+
+Podman and Docker use the same builder and conformance tests. Engine-specific arguments are limited to features such as Podman's `keep-id` user namespace.
+
+## Reporting
+
+`sandbox.configured` includes the provider, enforced controls, and structured details. Native details contain the Bubblewrap version, Landlock result, seccomp policy version, and rlimits. OCI details contain the engine version, image digest, privilege mode, runtime, seccomp and cgroups state, and limits.
+
+`daemon.info` reports the daemon's security mode, sandbox provider, and OCI image. `axl doctor` probes native, Podman, and Docker support without requiring provider credentials.
+
+## Compatibility
+
+The `details` field added to `sandbox.configured` is optional, so existing event logs remain readable. `daemon.info` adds response fields without changing its request shape. OCI selection is opt-in, and native sandboxing remains the default.
+
+The shell wrapper contract now optionally carries an idempotent cleanup callback. Existing array-valued wrappers remain valid.
+
+## Security limitations
+
+All implemented Linux backends share a kernel unless Docker Desktop supplies a VM. Landlock support depends on the running kernel ABI. Native resource limits use rlimits rather than cgroups. The native seccomp profile is a denylist. OCI image signatures, SBOM policy, registry credential helpers, egress brokering, and remote workers are outside this change.
+
+## Alternatives
+
+A Podman-only implementation was rejected because Docker compatibility can share the same narrow engine contract and conformance suite. Making Docker the default was rejected because rootless Podman provides a safer daemonless baseline. Pulling mutable image tags automatically was rejected because the executed artifact would not be reconstructable from the session log.

--- a/docs/security/assurance-case.md
+++ b/docs/security/assurance-case.md
@@ -36,7 +36,8 @@ Treat repository content, tool output, web content, extensions, MCP servers, imp
 - Runtime validation for canonical events and local wire messages
 - Redaction before canonical event-log writes
 - Canonical path checks, explicit file-tool readable roots, and symlink-escape rejection
-- Bubblewrap confinement on Linux with the user home masked, and Seatbelt profiles on macOS
+- Bubblewrap confinement on Linux with explicit Landlock read rules, a versioned seccomp denylist, dropped capabilities, private runtime directories, rlimits, and the user home masked
+- Digest-pinned Podman and Docker execution with read-only roots, restricted mounts, no network, seccomp, cgroups v2 limits, and verified container removal
 - Fail-closed startup when required isolation is unavailable, unless the user explicitly starts a separate `--unsafe` daemon
 - Logged unenforced state and a persistent terminal warning for unsafe sessions
 - Sandboxed stdio MCP servers with limited environment variables and no network
@@ -49,9 +50,13 @@ Treat repository content, tool output, web content, extensions, MCP servers, imp
 
 ## Remaining risks
 
-- Bubblewrap shares the host kernel and still exposes a read-only view of system paths outside the masked user home and protected paths. Complete shell-process read allowlists require the planned Landlock enforcement.
+- Bubblewrap, Landlock, seccomp, and ordinary OCI runtimes share the host kernel. They do not provide a virtual-machine boundary.
+- The current seccomp policy is a versioned high-risk syscall denylist rather than a complete syscall allowlist.
+- Landlock enforcement depends on the running kernel ABI. Axl reports partial enforcement when newer rights are unavailable.
+- Native Linux resource enforcement uses rlimits. Cgroups v2 limits are enforced by the OCI backends, not the native provider.
+- Docker may be rootful. Axl records this distinction; rootless Podman remains the preferred local OCI engine.
 - Seatbelt does not provide Linux-style namespaces.
-- Windows sandboxing and OCI isolation are not implemented yet.
+- Windows native sandboxing is not implemented yet.
 - Streamable HTTP MCP servers run remotely and must be trusted with requests sent to them.
 - GitHub branch protection and Private Vulnerability Reporting depend on repository settings outside this tree.
 - No signed release artifacts exist yet.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,3 +4,5 @@
 # `@axl/cli`
 
 This package owns the `axl` executable. It parses process arguments, manages local preferences and daemon connection startup, and selects the terminal client. Runtime assembly lives in `@axl/runtime`; terminal rendering lives in `@axl/tui`.
+
+Use `axl doctor` to inspect native, Podman, and Docker enforcement. Select local OCI execution with `--sandbox podman|docker --image <digest-pinned-reference>`. The CLI keeps each engine and image on a separate daemon socket and rejects attachment when the requested sandbox identity differs.

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -11,7 +11,12 @@ import type { AuthContext, CredentialStore } from "@axl/ai";
 import { AZURE_OPENAI_MODELS } from "@axl/ai/models";
 import { DaemonClient, WireClientError } from "@axl/daemon/client";
 import type { ThinkingLevel } from "@axl/protocol";
-import { startLocalDaemon } from "@axl/runtime";
+import {
+  diagnoseLocalSandboxes,
+  type LocalSandboxSelection,
+  localSandboxStateKey,
+  startLocalDaemon,
+} from "@axl/runtime";
 
 import { loadTuiSettings, saveTuiSettings, type TuiSettings } from "./settings.ts";
 
@@ -19,6 +24,7 @@ const AXL_VERSION = process.env.AXL_BUILD_VERSION ?? "0.0.0-dev";
 
 const HELP = `Usage: axl [session-id] [options]
        axl login
+       axl doctor
        axl daemon [options]
 
 Options:
@@ -28,19 +34,25 @@ Options:
   --theme <name>     Select the terminal theme
   --tui-mode <mode>  Use regular or fullscreen terminal mode
   --socket <path>    Use a custom daemon socket
+  --sandbox <kind>   Use native, podman, or docker isolation
+  --image <digest>   Use a locally available digest-pinned OCI image
   --unsafe           Disable operating-system isolation
   --help             Show this help
   --version          Show the installed version
 `;
 
+type SandboxChoice = "native" | "podman" | "docker";
+
 interface CliArguments {
-  command?: "login" | "daemon";
+  command?: "login" | "daemon" | "doctor";
   sessionId?: string;
   socket?: string;
   model?: string;
   thinking?: ThinkingLevel;
   theme?: string;
   tuiMode?: "regular" | "fullscreen";
+  image?: string;
+  sandbox: SandboxChoice;
   cwd: string;
   unsafe: boolean;
   showHelp: boolean;
@@ -50,6 +62,7 @@ interface CliArguments {
 function parseArguments(argv: readonly string[]): CliArguments {
   const parsed: CliArguments = {
     cwd: process.cwd(),
+    sandbox: "native",
     unsafe: false,
     showHelp: false,
     showVersion: false,
@@ -73,12 +86,29 @@ function parseArguments(argv: readonly string[]): CliArguments {
         throw new Error("--tui-mode requires regular or fullscreen");
       }
       parsed.tuiMode = mode;
+    } else if (argument === "--image") parsed.image = next();
+    else if (argument === "--sandbox") {
+      const sandbox = next();
+      if (!(["native", "podman", "docker"] as const).includes(sandbox as SandboxChoice)) {
+        throw new Error(`Unknown sandbox ${sandbox}; expected native, podman, or docker`);
+      }
+      parsed.sandbox = sandbox as SandboxChoice;
     } else if (argument === "--unsafe") parsed.unsafe = true;
     else if (argument === "--help" || argument === "-h") parsed.showHelp = true;
     else if (argument === "--version" || argument === "-v") parsed.showVersion = true;
-    else if (argument === "login" || argument === "daemon") parsed.command = argument;
-    else if (!argument.startsWith("-")) parsed.sessionId = argument;
+    else if (argument === "login" || argument === "daemon" || argument === "doctor") {
+      parsed.command = argument;
+    } else if (!argument.startsWith("-")) parsed.sessionId = argument;
     else throw new Error(`Unknown argument ${argument}`);
+  }
+  if (parsed.unsafe && parsed.sandbox !== "native") {
+    throw new Error("--unsafe cannot be combined with --sandbox podman or docker");
+  }
+  if (parsed.sandbox === "native" && parsed.image !== undefined) {
+    throw new Error("--image requires --sandbox podman or docker");
+  }
+  if (parsed.sandbox !== "native" && parsed.image === undefined && parsed.command !== "doctor") {
+    throw new Error(`--sandbox ${parsed.sandbox} requires --image with a sha256 digest`);
   }
   return parsed;
 }
@@ -114,19 +144,45 @@ interface ActiveConfig {
 }
 
 class SecurityModeMismatchError extends Error {
-  constructor(requested: "sandboxed" | "unsafe", actual: string) {
+  constructor(requested: string, actual: string) {
     super(`Daemon security mode is ${actual}; ${requested} was requested`);
     this.name = "SecurityModeMismatchError";
   }
 }
 
-async function connectExpectedDaemon(socketPath: string, unsafe: boolean): Promise<DaemonClient> {
+async function connectExpectedDaemon(
+  socketPath: string,
+  unsafe: boolean,
+  sandbox: SandboxChoice,
+  image?: string,
+): Promise<DaemonClient> {
   const client = await DaemonClient.connect(socketPath);
   try {
-    const info = (await client.request("daemon.info", {})) as { securityMode?: string };
-    const expected = unsafe ? "unsafe" : "sandboxed";
-    if (info.securityMode !== expected) {
-      throw new SecurityModeMismatchError(expected, info.securityMode ?? "unknown");
+    const info = (await client.request("daemon.info", {})) as {
+      securityMode?: string;
+      sandboxProvider?: string;
+      sandboxImage?: string;
+    };
+    const expectedMode = unsafe ? "unsafe" : "sandboxed";
+    if (info.securityMode !== expectedMode) {
+      throw new SecurityModeMismatchError(expectedMode, info.securityMode ?? "unknown");
+    }
+    const providers = unsafe
+      ? ["none", "unknown"]
+      : sandbox === "native"
+        ? ["bubblewrap", "seatbelt", "unknown"]
+        : [sandbox];
+    if (!providers.includes(info.sandboxProvider ?? "unknown")) {
+      throw new SecurityModeMismatchError(
+        `${expectedMode}/${sandbox}`,
+        `${info.securityMode ?? "unknown"}/${info.sandboxProvider ?? "unknown"}`,
+      );
+    }
+    if (image !== undefined && info.sandboxImage !== image) {
+      throw new SecurityModeMismatchError(
+        `${expectedMode}/${sandbox}/${image}`,
+        `${info.securityMode ?? "unknown"}/${info.sandboxProvider ?? "unknown"}/${info.sandboxImage ?? "unknown"}`,
+      );
     }
     return client;
   } catch (error) {
@@ -140,9 +196,11 @@ async function connectOrStartDaemon(input: {
   readonly model: string;
   readonly thinking: ThinkingLevel;
   readonly unsafe: boolean;
+  readonly sandbox: SandboxChoice;
+  readonly image?: string;
 }): Promise<DaemonClient> {
   try {
-    return await connectExpectedDaemon(input.socketPath, input.unsafe);
+    return await connectExpectedDaemon(input.socketPath, input.unsafe, input.sandbox, input.image);
   } catch (error) {
     if (error instanceof SecurityModeMismatchError) throw error;
     if (error instanceof WireClientError && error.code !== "connection_error") throw error;
@@ -161,6 +219,8 @@ async function connectOrStartDaemon(input: {
         "--thinking",
         input.thinking,
         ...(input.unsafe ? ["--unsafe"] : []),
+        ...(input.sandbox === "native" ? [] : ["--sandbox", input.sandbox]),
+        ...(input.image === undefined ? [] : ["--image", input.image]),
       ],
       { detached: true, stdio: "ignore" },
     );
@@ -181,7 +241,12 @@ async function connectOrStartDaemon(input: {
     while (Date.now() < deadline) {
       if (childFailure !== undefined) throw childFailure;
       try {
-        return await connectExpectedDaemon(input.socketPath, input.unsafe);
+        return await connectExpectedDaemon(
+          input.socketPath,
+          input.unsafe,
+          input.sandbox,
+          input.image,
+        );
       } catch (retryError) {
         if (retryError instanceof SecurityModeMismatchError) throw retryError;
         lastError = retryError;
@@ -234,7 +299,20 @@ async function main(): Promise<void> {
   const startupIndicator = cli.command === undefined && showStartupIndicator("starting…");
   const tuiModule = cli.command === undefined ? import("@axl/tui") : undefined;
   const axlHome = join(homedir(), ".axl");
-  const stateDirectory = cli.unsafe ? join(axlHome, "unsafe") : axlHome;
+  if (cli.command === "doctor") {
+    process.stdout.write(`${JSON.stringify(await diagnoseLocalSandboxes(), null, 2)}\n`);
+    return;
+  }
+  const sandbox: LocalSandboxSelection =
+    cli.sandbox === "native"
+      ? { type: "native" }
+      : { type: "oci", engine: cli.sandbox, image: cli.image as string };
+  const sandboxStateKey = localSandboxStateKey(sandbox);
+  const stateDirectory = cli.unsafe
+    ? join(axlHome, "unsafe")
+    : sandboxStateKey === undefined
+      ? axlHome
+      : join(axlHome, sandboxStateKey);
   await mkdir(stateDirectory, { recursive: true, mode: 0o700 });
   const socketPath = cli.socket ?? join(stateDirectory, "axl.sock");
   const settingsPath = join(axlHome, "settings.json");
@@ -280,6 +358,7 @@ async function main(): Promise<void> {
       defaults: active,
       store,
       unsafe: cli.unsafe,
+      sandbox,
     });
     const stop = (): void => {
       void daemon.stop().finally(() => process.exit(0));
@@ -292,7 +371,7 @@ async function main(): Promise<void> {
 
   let client: DaemonClient;
   try {
-    client = await connectExpectedDaemon(socketPath, cli.unsafe);
+    client = await connectExpectedDaemon(socketPath, cli.unsafe, cli.sandbox, cli.image);
     timing.mark("daemon connect");
   } catch (error) {
     if (error instanceof SecurityModeMismatchError) throw error;
@@ -304,6 +383,8 @@ async function main(): Promise<void> {
       model: active.modelId,
       thinking: active.thinkingLevel,
       unsafe: cli.unsafe,
+      sandbox: cli.sandbox,
+      ...(cli.image === undefined ? {} : { image: cli.image }),
     });
     timing.mark("daemon start");
   }
@@ -356,6 +437,8 @@ async function main(): Promise<void> {
         model: active.modelId,
         thinking: active.thinkingLevel,
         unsafe: cli.unsafe,
+        sandbox: cli.sandbox,
+        ...(cli.image === undefined ? {} : { image: cli.image }),
       }),
     onPreferenceChange: persistSettings,
     models: AZURE_OPENAI_MODELS.map((model) => model.modelId),

--- a/packages/cli/test/unsafe-cli.test.ts
+++ b/packages/cli/test/unsafe-cli.test.ts
@@ -52,6 +52,58 @@ async function stopChild(child: ChildProcess): Promise<void> {
   await new Promise<void>((resolvePromise) => child.once("exit", () => resolvePromise()));
 }
 
+async function runCli(args: readonly string[]): Promise<{ code: number | null; stderr: string }> {
+  let stderr = "";
+  const child = spawn(process.execPath, [entry, ...args], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+  });
+  const code = await new Promise<number | null>((resolvePromise) =>
+    child.once("exit", (value) => resolvePromise(value)),
+  );
+  return { code, stderr };
+}
+
+test("OCI CLI arguments fail closed", async () => {
+  const missingImage = await runCli(["--sandbox", "podman"]);
+  assert.equal(missingImage.code, 1);
+  assert.match(missingImage.stderr, /requires --image with a sha256 digest/);
+  const unsafeOci = await runCli([
+    "--unsafe",
+    "--sandbox",
+    "docker",
+    "--image",
+    "example.invalid/image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  ]);
+  assert.equal(unsafeOci.code, 1);
+  assert.match(unsafeOci.stderr, /--unsafe cannot be combined/);
+});
+
+test("doctor reports native, Podman, and Docker capabilities without credentials", async () => {
+  let stdout = "";
+  let stderr = "";
+  const child = spawn(process.execPath, [entry, "doctor"], {
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+  });
+  const exitCode = await new Promise<number | null>((resolvePromise) =>
+    child.once("exit", (code) => resolvePromise(code)),
+  );
+  assert.equal(exitCode, 0, stderr);
+  const report = JSON.parse(stdout) as Record<string, unknown>;
+  assert.equal(typeof report.native, "object");
+  assert.equal(typeof report.podman, "object");
+  assert.equal(typeof report.docker, "object");
+});
+
 test("--unsafe starts a separate unenforced daemon and records the warning state", async (context) => {
   const home = await temporaryDirectory(context);
   const workspace = join(home, "workspace");
@@ -75,7 +127,10 @@ test("--unsafe starts a separate unenforced daemon and records the warning state
   const socketPath = join(stateDirectory, "axl.sock");
   const client = await connectEventually(socketPath, child);
   context.after(() => client.close());
-  assert.deepEqual(await client.request("daemon.info", {}), { securityMode: "unsafe" });
+  assert.deepEqual(await client.request("daemon.info", {}), {
+    securityMode: "unsafe",
+    sandboxProvider: "none",
+  });
 
   const created = (await client.request("session.create", { cwd: workspace })) as SessionSnapshot;
   const sandbox = created.events.find((event) => event.type === "sandbox.configured");
@@ -157,4 +212,30 @@ test("clients refuse a daemon with the opposite security mode", async (context) 
     false,
     /Daemon security mode is unsafe; sandboxed was requested/,
   );
+});
+
+test("clients refuse a different OCI engine or image", async (context) => {
+  const directory = await temporaryDirectory(context);
+  const socketPath = join(directory, "axl.sock");
+  const firstImage = `example.invalid/image@sha256:${"a".repeat(64)}`;
+  const secondImage = `example.invalid/image@sha256:${"b".repeat(64)}`;
+  const daemon = new AxlDaemon({
+    socketPath,
+    dataDirectory: join(directory, "data"),
+    securityMode: "sandboxed",
+    sandboxProvider: "podman",
+    sandboxImage: firstImage,
+    runtime: () => ({ model: idleModel, tools: new ToolRegistry() }),
+  });
+  await daemon.start();
+  context.after(() => daemon.stop());
+
+  for (const args of [
+    ["--sandbox", "docker", "--image", firstImage],
+    ["--sandbox", "podman", "--image", secondImage],
+  ]) {
+    const result = await runCli([...args, "--socket", socketPath]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /Daemon security mode is sandboxed\/podman/);
+  }
 });

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -5,4 +5,4 @@
 
 The daemon owns sessions, agent loops, event logs, and active operations. Clients connect through a local Unix socket, load bounded history pages, and follow the live event stream. They do not keep their own copy of the agent loop.
 
-The local wire protocol uses newline-delimited JSON and requires an exact `WIRE_PROTOCOL_VERSION` match. It currently supports session creation, listing, paged history, resume, fork, clone, subscriptions, turns, interruption, reload, live activity, abortable blob transport, workspace review, model and thinking configuration, and user interactions requested by extensions. Phase 9 adds the full RPC surface and generated SDK.
+The local wire protocol uses newline-delimited JSON and requires an exact `WIRE_PROTOCOL_VERSION` match. It currently supports daemon security and sandbox identity, session creation, listing, paged history, resume, fork, clone, subscriptions, turns, interruption, reload, live activity, abortable blob transport, workspace review, model and thinking configuration, and user interactions requested by extensions. Phase 9 adds the full RPC surface and generated SDK.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -24,6 +24,8 @@ export type DaemonSecurityMode = "sandboxed" | "unsafe";
 export interface DaemonOptions extends SessionManagerOptions {
   readonly socketPath: string;
   readonly securityMode?: DaemonSecurityMode;
+  readonly sandboxProvider?: string;
+  readonly sandboxImage?: string;
 }
 
 const MAX_REQUEST_BYTES = 1_048_576;
@@ -83,6 +85,8 @@ export class AxlDaemon {
   readonly sessions: SessionManager;
   private readonly socketPath: string;
   private readonly securityMode: DaemonSecurityMode;
+  private readonly sandboxProvider: string;
+  private readonly sandboxImage: string | undefined;
   private server: Server | undefined;
   private socketIdentity: SocketIdentity | undefined;
   private readonly connections = new Set<Socket>();
@@ -91,6 +95,8 @@ export class AxlDaemon {
     this.sessions = new SessionManager(options);
     this.socketPath = options.socketPath;
     this.securityMode = options.securityMode ?? "sandboxed";
+    this.sandboxProvider = options.sandboxProvider ?? "unknown";
+    this.sandboxImage = options.sandboxImage;
   }
 
   async start(): Promise<void> {
@@ -226,7 +232,11 @@ export class AxlDaemon {
   ): Promise<unknown> {
     switch (request.method) {
       case "daemon.info":
-        return { securityMode: this.securityMode };
+        return {
+          securityMode: this.securityMode,
+          sandboxProvider: this.sandboxProvider,
+          ...(this.sandboxImage === undefined ? {} : { sandboxImage: this.sandboxImage }),
+        };
       case "session.create": {
         const { cwd, modelId, thinkingLevel } = request.params;
         return this.sessions.create(cwd, {

--- a/packages/daemon/test/daemon.test.ts
+++ b/packages/daemon/test/daemon.test.ts
@@ -68,6 +68,8 @@ async function startDaemon(
   context: TestContext,
   port: ModelPort = replyPort(),
   securityMode: "sandboxed" | "unsafe" = "sandboxed",
+  sandboxProvider?: string,
+  sandboxImage?: string,
 ): Promise<{ daemon: AxlDaemon; socketPath: string; dataDirectory: string; cwd: string }> {
   const directory = await mkdtemp(join(tmpdir(), "axl-daemon-"));
   context.after(() => rm(directory, { recursive: true, force: true }));
@@ -76,6 +78,8 @@ async function startDaemon(
     socketPath,
     dataDirectory: join(directory, "data"),
     securityMode,
+    ...(sandboxProvider === undefined ? {} : { sandboxProvider }),
+    ...(sandboxImage === undefined ? {} : { sandboxImage }),
     runtime: () => ({ model: port, tools: new ToolRegistry(), system: "You are Axl." }),
   });
   await daemon.start();
@@ -93,12 +97,26 @@ test("reports the daemon security mode", async (context) => {
   context.after(() => sandboxedClient.close());
   assert.deepEqual(await sandboxedClient.request("daemon.info", {}), {
     securityMode: "sandboxed",
+    sandboxProvider: "unknown",
   });
 
   const unsafe = await startDaemon(context, replyPort(), "unsafe");
   const unsafeClient = await DaemonClient.connect(unsafe.socketPath);
   context.after(() => unsafeClient.close());
-  assert.deepEqual(await unsafeClient.request("daemon.info", {}), { securityMode: "unsafe" });
+  assert.deepEqual(await unsafeClient.request("daemon.info", {}), {
+    securityMode: "unsafe",
+    sandboxProvider: "unknown",
+  });
+
+  const image = `example.invalid/image@sha256:${"a".repeat(64)}`;
+  const oci = await startDaemon(context, replyPort(), "sandboxed", "podman", image);
+  const ociClient = await DaemonClient.connect(oci.socketPath);
+  context.after(() => ociClient.close());
+  assert.deepEqual(await ociClient.request("daemon.info", {}), {
+    securityMode: "sandboxed",
+    sandboxProvider: "podman",
+    sandboxImage: image,
+  });
 });
 
 test("creates a session, streams the live tail, and answers sends", async (context) => {

--- a/packages/extensions/mcp/src/manager.ts
+++ b/packages/extensions/mcp/src/manager.ts
@@ -72,6 +72,7 @@ interface Connection {
   readonly client: AnyClient;
   readonly transport: McpTransport;
   readonly oauth?: OAuthSession;
+  readonly cleanup?: () => Promise<void>;
   readonly taskStore: TaskStore;
   readonly logs: JsonValue[];
 }
@@ -675,6 +676,7 @@ export class McpManager implements ExtensionHost {
       },
     );
     let oauthForClose: OAuthSession | undefined;
+    let cleanupForClose: (() => Promise<void>) | undefined;
     client.onerror = (error) => this.pushLog(logs, { level: "error", data: error.message });
     client.onclose = () => {
       this.pushLog(logs, { level: "info", data: "connection closed" });
@@ -682,6 +684,9 @@ export class McpManager implements ExtensionHost {
       void oauthForClose
         ?.close()
         .catch((error: unknown) => this.pushLog(logs, { level: "error", data: String(error) }));
+      void cleanupForClose?.().catch((error: unknown) =>
+        this.pushLog(logs, { level: "error", data: String(error) }),
+      );
     };
     client.setRequestHandler(ListRootsRequestSchema, async () => ({
       roots: await this.roots(server.config),
@@ -710,6 +715,7 @@ export class McpManager implements ExtensionHost {
 
     const opened = await this.transport(server, signal);
     oauthForClose = opened.oauth;
+    cleanupForClose = opened.cleanup;
     try {
       await client.connect(
         opened.transport as unknown as Transport,
@@ -718,6 +724,7 @@ export class McpManager implements ExtensionHost {
     } catch (error) {
       if (!(error instanceof UnauthorizedError) || !opened.oauth) {
         await opened.oauth?.close();
+        await opened.cleanup?.();
         throw error;
       }
       const code = opened.oauth.provider.takeAuthorizationCode();
@@ -734,12 +741,20 @@ export class McpManager implements ExtensionHost {
         retried.transport as unknown as Transport,
         this.requestOptions(server.config, signal, logs),
       );
-      return { client, transport: retried.transport, oauth: opened.oauth, taskStore, logs };
+      return {
+        client,
+        transport: retried.transport,
+        oauth: opened.oauth,
+        ...(retried.cleanup === undefined ? {} : { cleanup: retried.cleanup }),
+        taskStore,
+        logs,
+      };
     }
     return {
       client,
       transport: opened.transport,
       ...(opened.oauth ? { oauth: opened.oauth } : {}),
+      ...(opened.cleanup === undefined ? {} : { cleanup: opened.cleanup }),
       taskStore,
       logs,
     };
@@ -749,7 +764,11 @@ export class McpManager implements ExtensionHost {
     server: NamedMcpServerConfig,
     signal: AbortSignal,
     existingOAuth?: OAuthSession,
-  ): Promise<{ transport: McpTransport; oauth?: OAuthSession }> {
+  ): Promise<{
+    transport: McpTransport;
+    oauth?: OAuthSession;
+    cleanup?: () => Promise<void>;
+  }> {
     const env = this.options.env ?? process.env;
     if (server.config.transport === "stdio") {
       const wrapped = this.options.wrapStdio({
@@ -758,6 +777,15 @@ export class McpManager implements ExtensionHost {
         cwd: server.config.cwd ?? this.options.cwd,
         env: safeEnvironment(server.config.env, env),
       });
+      let cleanupPromise: Promise<void> | undefined;
+      const cleanupOperation = wrapped.cleanup;
+      const cleanup =
+        cleanupOperation === undefined
+          ? undefined
+          : () => {
+              cleanupPromise ??= cleanupOperation();
+              return cleanupPromise;
+            };
       return {
         transport: new StdioClientTransport({
           command: wrapped.command,
@@ -767,6 +795,7 @@ export class McpManager implements ExtensionHost {
           stderr: "ignore",
           maxBufferSize: MAX_BLOB_BYTES * 2,
         }),
+        ...(cleanup === undefined ? {} : { cleanup }),
       };
     }
 
@@ -1025,6 +1054,11 @@ export class McpManager implements ExtensionHost {
     }
     try {
       await connection.oauth?.close();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await connection.cleanup?.();
     } catch (error) {
       errors.push(error);
     }

--- a/packages/extensions/mcp/src/types.ts
+++ b/packages/extensions/mcp/src/types.ts
@@ -23,6 +23,8 @@ export interface WrappedMcpProcess {
   readonly args: readonly string[];
   readonly cwd: string;
   readonly env: Readonly<Record<string, string>>;
+  /** Idempotent process-backend cleanup and termination verification. */
+  readonly cleanup?: () => Promise<void>;
 }
 
 export interface McpManagerOptions {

--- a/packages/extensions/mcp/test/manager.test.ts
+++ b/packages/extensions/mcp/test/manager.test.ts
@@ -55,6 +55,7 @@ function managerFor(input: {
   config: ConstructorParameters<typeof McpManager>[0]["servers"][number];
   env?: Readonly<Record<string, string | undefined>>;
   secretValues?: readonly string[];
+  cleanup?: () => Promise<void>;
 }): McpManager {
   return new McpManager({
     servers: [input.config],
@@ -73,6 +74,7 @@ function managerFor(input: {
           (entry): entry is [string, string] => entry[1] !== undefined,
         ),
       ),
+      ...(input.cleanup === undefined ? {} : { cleanup: input.cleanup }),
     }),
     env: input.env ?? { PATH: process.env.PATH },
   });
@@ -85,10 +87,15 @@ async function execute(manager: McpManager, input: JsonObject) {
 test("stdio MCP supports discovery, tools, resources, prompts, roots, sampling, and elicitation", async (context) => {
   const cwd = await workspace(context);
   const seen: McpInteractionRequest[] = [];
+  let cleanupCalls = 0;
   const manager = managerFor({
     cwd,
     interactions: seen,
     secretValues: ["top-secret"],
+    cleanup: () => {
+      cleanupCalls += 1;
+      return Promise.resolve();
+    },
     config: {
       name: "fixture",
       source: "test",
@@ -180,6 +187,8 @@ test("stdio MCP supports discovery, tools, resources, prompts, roots, sampling, 
   ) as { roots: { roots: Array<{ uri: string }> }; sampled: { content: { text: string } } };
   assert.equal(payload.roots.roots[0]?.uri, pathToFileURL(cwd).href);
   assert.equal(payload.sampled.content.text, "fixture sample");
+  await manager.dispose();
+  assert.equal(cleanupCalls, 1);
 });
 
 test("Streamable HTTP completes OAuth discovery, PKCE, registration, and token use", async (context) => {

--- a/packages/kernel/src/tools/shell.ts
+++ b/packages/kernel/src/tools/shell.ts
@@ -17,6 +17,12 @@ import {
   requiredString,
 } from "./validate.ts";
 
+export interface WrappedShellCommand {
+  readonly argv: readonly string[];
+  /** Idempotent cleanup and absence verification after the process exits. */
+  readonly cleanup?: () => Promise<void>;
+}
+
 export interface ShellToolOptions {
   /** Default working directory for commands. */
   readonly cwd: string;
@@ -29,7 +35,7 @@ export interface ShellToolOptions {
    * default runs `bash -c` directly; a sandbox provider substitutes its own
    * confinement wrapper. Overflow preservation stays harness-side either way.
    */
-  readonly wrapCommand?: (command: string, cwd: string) => readonly string[];
+  readonly wrapCommand?: (command: string, cwd: string) => readonly string[] | WrappedShellCommand;
   /** Bytes of output the model sees before truncation. */
   readonly maxOutputBytes?: number;
   readonly defaultTimeoutMs?: number;
@@ -163,9 +169,17 @@ export function makeShellTool(options: ShellToolOptions): KernelTool {
         options.defaultTimeoutMs ??
         DEFAULT_TIMEOUT_MS;
 
-      const argv = options.wrapCommand?.(command, cwd) ?? ["bash", "-c", command];
+      const wrapped = options.wrapCommand?.(command, cwd) ?? ["bash", "-c", command];
+      const invocation: WrappedShellCommand = Array.isArray(wrapped)
+        ? { argv: wrapped }
+        : (wrapped as WrappedShellCommand);
       const started = Date.now();
-      const capture = await runCommand(argv, cwd, timeoutMs, signal);
+      let capture: CommandCapture;
+      try {
+        capture = await runCommand(invocation.argv, cwd, timeoutMs, signal);
+      } finally {
+        await invocation.cleanup?.();
+      }
       const durationMs = Date.now() - started;
 
       let visible = capture.output.toString("utf8");

--- a/packages/kernel/test/canonical-tools.test.ts
+++ b/packages/kernel/test/canonical-tools.test.ts
@@ -143,6 +143,31 @@ test("shell abort terminates descendant processes and never starts with a spent 
   assert.equal(state === undefined || state === "Z", true);
 });
 
+test("shell runs backend cleanup after success and failure", async (context) => {
+  const cwd = await workspace(context);
+  let cleanups = 0;
+  const shell = shellIn(cwd, {
+    wrapCommand: (command) => ({
+      argv: ["bash", "-c", command],
+      cleanup: () => {
+        cleanups += 1;
+        return Promise.resolve();
+      },
+    }),
+  });
+  await shell.execute({ command: "true" }, noSignal);
+  await shell.execute({ command: "exit 7" }, noSignal);
+  assert.equal(cleanups, 2);
+
+  const brokenCleanup = shellIn(cwd, {
+    wrapCommand: (command) => ({
+      argv: ["bash", "-c", command],
+      cleanup: () => Promise.reject(new Error("cleanup failed")),
+    }),
+  });
+  await assert.rejects(brokenCleanup.execute({ command: "true" }, noSignal), /cleanup failed/);
+});
+
 test("shell truncates the model surface but preserves the complete output", async (context) => {
   const cwd = await workspace(context);
   const shell = shellIn(cwd, { maxOutputBytes: 1_000 });

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -122,6 +122,7 @@ export type EventPayloadMap = {
     readonly provider: string;
     readonly enforced: boolean;
     readonly controls: readonly string[];
+    readonly details?: JsonObject;
   };
   "sandbox.violation": { readonly capability: string; readonly reason: string };
   "context.compacted": {
@@ -443,10 +444,11 @@ const payloadParsers: { readonly [Type in EventType]: PayloadParser } = {
     return payload;
   },
   "sandbox.configured": (payload, path) => {
-    exact(payload, path, ["provider", "enforced", "controls"]);
+    exact(payload, path, ["provider", "enforced", "controls"], ["details"]);
     string(payload.provider, `${path}.provider`);
     boolean(payload.enforced, `${path}.enforced`);
     validateStringArray(payload.controls, `${path}.controls`);
+    if (payload.details !== undefined) object(payload.details, `${path}.details`);
     return payload;
   },
   "sandbox.violation": (payload, path) => {

--- a/packages/protocol/test/events.test.ts
+++ b/packages/protocol/test/events.test.ts
@@ -86,7 +86,12 @@ const validPayloads = {
     action: "accept",
     content: { answer: "yes" },
   },
-  "sandbox.configured": { provider: "bubblewrap", enforced: true, controls: ["filesystem"] },
+  "sandbox.configured": {
+    provider: "bubblewrap",
+    enforced: true,
+    controls: ["filesystem"],
+    details: { landlock: "full", seccompPolicy: "axl-linux-deny-v1" },
+  },
   "sandbox.violation": { capability: "filesystem.write", reason: "outside workspace" },
   "context.compacted": { summary: "Earlier work", replacedEventIds: [secondEventId] },
   "session.error": { code: "provider_failed", message: "Provider unavailable", retryable: true },

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -3,6 +3,6 @@
 
 # `@axl/runtime`
 
-This package assembles Axl's client-independent local runtime. It selects the operating-system sandbox, constructs the provider and canonical tools, loads skills and MCP servers, and starts the authoritative daemon.
+This package assembles Axl's client-independent local runtime. It selects the native, Podman, or Docker sandbox, constructs the provider and canonical tools, loads skills and MCP servers, and starts the authoritative daemon.
 
 Presentation clients must not be imported here. Terminal, web, IDE, and headless clients attach through the daemon protocol and do not construct separate agent loops.

--- a/packages/runtime/src/local-runtime.ts
+++ b/packages/runtime/src/local-runtime.ts
@@ -13,6 +13,64 @@ export interface LocalRuntimeDefaults {
   readonly thinkingLevel: ThinkingLevel;
 }
 
+export type LocalSandboxSelection =
+  | { readonly type: "native" }
+  | { readonly type: "oci"; readonly engine: "podman" | "docker"; readonly image: string };
+
+export function localSandboxStateKey(selection: LocalSandboxSelection): string | undefined {
+  if (selection.type === "native") return undefined;
+  const separatorText = "@sha256:";
+  const separator = selection.image.lastIndexOf(separatorText);
+  const name = separator < 1 ? "" : selection.image.slice(0, separator);
+  const digest = separator < 0 ? "" : selection.image.slice(separator + separatorText.length);
+  let digestValid = digest.length === 64;
+  for (const character of digest) {
+    const code = character.charCodeAt(0);
+    if (!((code >= 48 && code <= 57) || (code >= 97 && code <= 102))) digestValid = false;
+  }
+  const nameValid =
+    name.length > 0 &&
+    !name.includes("@") &&
+    ![...name].some((character) => character.trim() === "");
+  if (!nameValid || !digestValid) {
+    throw new Error(
+      `OCI image must be pinned to a sha256 digest, received ${JSON.stringify(selection.image)}`,
+    );
+  }
+  return join("oci", selection.engine, digest);
+}
+
+export async function diagnoseLocalSandboxes(): Promise<{
+  readonly native: {
+    readonly provider: string;
+    readonly available: boolean;
+    readonly reason?: string;
+    readonly controls: readonly string[];
+    readonly details?: Readonly<Record<string, unknown>>;
+  };
+  readonly podman: Awaited<ReturnType<typeof import("@axl/sandbox")["detectOciEngine"]>>;
+  readonly docker: Awaited<ReturnType<typeof import("@axl/sandbox")["detectOciEngine"]>>;
+}> {
+  const sandboxPackage = await import("@axl/sandbox");
+  const [native, podman, docker] = await Promise.all([
+    sandboxPackage.detectPlatformSandbox(),
+    sandboxPackage.detectOciEngine("podman"),
+    sandboxPackage.detectOciEngine("docker"),
+  ]);
+  const nativePayload = native.configuredPayload();
+  return {
+    native: {
+      provider: native.provider,
+      available: native.available,
+      ...(native.reason === undefined ? {} : { reason: native.reason }),
+      controls: nativePayload.controls,
+      ...(nativePayload.details === undefined ? {} : { details: nativePayload.details }),
+    },
+    podman,
+    docker,
+  };
+}
+
 async function exists(path: string): Promise<boolean> {
   try {
     await access(path);
@@ -30,6 +88,7 @@ export interface LocalDaemonOptions {
   readonly defaults: LocalRuntimeDefaults;
   readonly store: CredentialStore;
   readonly unsafe: boolean;
+  readonly sandbox?: LocalSandboxSelection;
 }
 
 /**
@@ -38,11 +97,12 @@ export interface LocalDaemonOptions {
  */
 export async function startLocalDaemon(options: LocalDaemonOptions): Promise<AxlDaemon> {
   const { axlHome, stateDirectory, socketPath, defaults, store, unsafe } = options;
+  const sandboxSelection = options.sandbox ?? { type: "native" as const };
   let assemblyPromise:
     | Promise<{
         ai: typeof import("@axl/ai");
         kernel: typeof import("@axl/kernel");
-        sandbox: Awaited<ReturnType<typeof import("@axl/sandbox")["detectPlatformSandbox"]>>;
+        sandbox: import("@axl/sandbox").PlatformSandbox;
         provider: ReturnType<typeof import("@axl/ai")["createAzureOpenAiProvider"]>;
       }>
     | undefined;
@@ -54,7 +114,12 @@ export async function startLocalDaemon(options: LocalDaemonOptions): Promise<Axl
     ]).then(async ([ai, kernel, sandboxPackage]) => {
       const sandbox = unsafe
         ? sandboxPackage.createUnsafePlatformExecution()
-        : await sandboxPackage.detectPlatformSandbox();
+        : sandboxSelection.type === "native"
+          ? await sandboxPackage.detectPlatformSandbox()
+          : await sandboxPackage.prepareOciPlatformExecution({
+              engine: sandboxSelection.engine,
+              image: sandboxSelection.image,
+            });
       if (!sandbox.available) {
         throw new sandboxPackage.SandboxUnavailableError(sandbox.reason ?? "unknown");
       }
@@ -70,12 +135,14 @@ export async function startLocalDaemon(options: LocalDaemonOptions): Promise<Axl
 
   // Sandboxed startup fails closed before listening. Unsafe startup may listen
   // first because its lack of isolation is already explicit and logged.
-  if (!unsafe) await loadAssembly();
+  const initialAssembly = unsafe ? undefined : await loadAssembly();
   const { AxlDaemon } = await import("@axl/daemon");
   const daemon = new AxlDaemon({
     socketPath,
     dataDirectory: stateDirectory,
     securityMode: unsafe ? "unsafe" : "sandboxed",
+    sandboxProvider: unsafe ? "none" : (initialAssembly?.sandbox.provider ?? "unknown"),
+    ...(sandboxSelection.type === "oci" ? { sandboxImage: sandboxSelection.image } : {}),
     runtime: async ({ sessionId, cwd, boundary, selection, interact, readBlob }) => {
       const { ai, kernel, sandbox, provider } = await loadAssembly();
       const [hasMcpConfig, hasSkills] = await Promise.all([

--- a/packages/runtime/test/local-runtime.test.ts
+++ b/packages/runtime/test/local-runtime.test.ts
@@ -10,7 +10,27 @@ import test from "node:test";
 import { FileCredentialStore } from "@axl/ai";
 import { DaemonClient, type SessionSnapshot } from "@axl/daemon";
 
-import { startLocalDaemon } from "../src/index.ts";
+import { localSandboxStateKey, startLocalDaemon } from "../src/index.ts";
+
+test("OCI state keys require a digest and cannot traverse directories", () => {
+  assert.equal(
+    localSandboxStateKey({
+      type: "oci",
+      engine: "podman",
+      image: `example.invalid/image@sha256:${"a".repeat(64)}`,
+    }),
+    join("oci", "podman", "a".repeat(64)),
+  );
+  assert.throws(
+    () =>
+      localSandboxStateKey({
+        type: "oci",
+        engine: "docker",
+        image: "example.invalid/image@sha256:../../outside",
+      }),
+    /must be pinned/,
+  );
+});
 
 test("assembles an authoritative local runtime without a presentation client", async (context) => {
   const root = await mkdtemp(join(tmpdir(), "axl-runtime-"));
@@ -42,7 +62,10 @@ test("assembles an authoritative local runtime without a presentation client", a
   const client = await DaemonClient.connect(socketPath);
   context.after(() => client.close());
 
-  assert.deepEqual(await client.request("daemon.info", {}), { securityMode: "unsafe" });
+  assert.deepEqual(await client.request("daemon.info", {}), {
+    securityMode: "unsafe",
+    sandboxProvider: "none",
+  });
   const snapshot = (await client.request("session.create", { cwd: workspace })) as SessionSnapshot;
   const sandbox = snapshot.events.find((event) => event.type === "sandbox.configured");
   assert.deepEqual(sandbox?.type === "sandbox.configured" ? sandbox.payload : undefined, {

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -3,6 +3,8 @@
 
 # `@axl/sandbox`
 
-This package provides operating-system sandbox adapters. Linux uses Bubblewrap with a read-only root, writable workspace, masked user home and Axl state, isolated networking, and a cleared environment. macOS uses Seatbelt to restrict writes, network access, protected paths, and environment variables. In-process tools allow reads only from explicit readable roots and apply the same protected-path and workspace-write policy through the kernel's canonical path checks.
+This package provides operating-system and OCI sandbox adapters. Linux combines Bubblewrap namespaces with Landlock filesystem rules, a versioned seccomp denylist, dropped capabilities, private runtime directories, process supervision, and rlimits. macOS uses Seatbelt to restrict writes, network access, protected paths, and environment variables. In-process tools allow reads only from explicit readable roots and apply the same protected-path and workspace-write policy through the kernel's canonical path checks.
 
-A session that requires isolation will not start without a suitable provider. Each provider records the controls it actually enforces in `sandbox.configured`. Seatbelt reports that it cannot provide Linux-style namespaces. Landlock, seccomp, Windows support, and the OCI runtime remain Phase 7 work.
+The OCI backend supports Podman and Docker with digest-pinned local images. It applies a read-only root, workspace-only persistent writes, private temporary storage, no network, dropped capabilities, `no-new-privileges`, seccomp, cgroups v2 limits, rlimits, and verified container removal. Podman must be rootless. Docker reports whether it is rootless, VM-backed, or rootful.
+
+A session that requires isolation will not start without a suitable provider. Each provider records the controls, versions, image, privilege mode, and limits it actually enforces in `sandbox.configured.details`. Seatbelt reports that it cannot provide Linux-style namespaces. Windows native sandboxing remains future work.

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "OS sandbox providers for Axl tool execution",
+  "description": "Native sandbox providers for Axl tool execution",
   "license": "Apache-2.0",
   "exports": {
     ".": {
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@axl/kernel": "workspace:*",
-    "@axl/protocol": "workspace:*"
+    "@axl/protocol": "workspace:*",
+    "@deepseek-ai/node-addon-landlock-run": "0.1.1"
   }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Native sandbox providers for Axl tool execution",
+  "description": "Native and OCI sandbox providers for Axl tool execution",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/packages/sandbox/src/bubblewrap.ts
+++ b/packages/sandbox/src/bubblewrap.ts
@@ -2,9 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFile } from "node:child_process";
-import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { promisify } from "node:util";
+
+import {
+  grantArgs,
+  launcherPath,
+  type LandlockEnforcement,
+  probe as probeLandlock,
+} from "@deepseek-ai/node-addon-landlock-run";
 
 import {
   makeShellTool,
@@ -15,6 +24,7 @@ import {
 import type { EventPayloadMap } from "@axl/protocol";
 
 import { allowlistedEnvironment, definedEnvironment } from "./environment.ts";
+import { ensureSeccompFilterFile, SECCOMP_POLICY_VERSION } from "./seccomp.ts";
 
 const run = promisify(execFile);
 
@@ -25,8 +35,37 @@ export class SandboxUnavailableError extends Error {
   }
 }
 
-/** The controls the Phase 4 Bubblewrap provider actually enforces. */
+const LANDLOCK_MOUNT_PATH = "/run/axl/landlock-run";
+const SECCOMP_FD = 3;
+const SECCOMP_WRAPPER = 'exec 3<"$1"; shift; exec "$@"';
+const SYSTEM_READ_ROOTS = [
+  "/bin",
+  "/sbin",
+  "/usr",
+  "/lib",
+  "/lib64",
+  "/etc/alternatives",
+  "/etc/ld.so.cache",
+  "/etc/ld.so.conf",
+  "/etc/ld.so.conf.d",
+  "/etc/nsswitch.conf",
+  "/etc/passwd",
+  "/etc/group",
+  "/etc/ssl",
+  "/proc",
+] as const;
+const DEVICE_GRANTS = ["/dev/null", "/dev/random", "/dev/urandom", "/dev/tty"] as const;
+const NATIVE_LIMITS = {
+  addressSpaceBytes: 4_294_967_296,
+  cpuSeconds: 120,
+  fileSizeBytes: 268_435_456,
+  openFiles: 1024,
+  processes: 256,
+} as const;
+
+/** Controls enforced whenever the Linux native provider is available. */
 export const BUBBLEWRAP_CONTROLS: readonly string[] = [
+  "filesystem.read-allowlist",
   "filesystem.readonly-root",
   "filesystem.workspace-writes",
   "filesystem.masked-protected-paths",
@@ -34,12 +73,52 @@ export const BUBBLEWRAP_CONTROLS: readonly string[] = [
   "network.none",
   "environment.cleared",
   "process.namespaces",
+  "process.userns-disabled",
+  "process.capabilities-dropped",
+  "process.landlock",
+  `process.seccomp.${SECCOMP_POLICY_VERSION}`,
+  "resources.rlimits",
 ];
 
 export interface BubblewrapCapabilities {
   readonly available: boolean;
   readonly version?: string;
+  readonly landlock?: LandlockEnforcement;
+  readonly landlockFilesystemComplete?: boolean;
+  readonly landlockLauncher?: string;
+  readonly seccompPolicyPath?: string;
   readonly reason?: string;
+}
+
+async function probeLandlockFilesystem(landlockBinary: string): Promise<boolean> {
+  const root = await mkdtemp(join(tmpdir(), "axl-landlock-probe-"));
+  const allowed = join(root, "allowed");
+  const allowedFile = join(allowed, "allowed");
+  const outside = join(root, "outside");
+  try {
+    if (!existsSync("/usr/bin/truncate")) return false;
+    await mkdir(allowed);
+    await writeFile(allowedFile, "allowed");
+    await writeFile(outside, "must-remain");
+    const grants = grantArgs({
+      readOnly: SYSTEM_READ_ROOTS.filter((path) => existsSync(path)),
+      readWrite: [allowed],
+    });
+    await run(landlockBinary, [...grants, "--", "/usr/bin/truncate", "-s", "0", allowedFile], {
+      timeout: 2_000,
+    });
+    if ((await readFile(allowedFile)).byteLength !== 0) return false;
+    try {
+      await run(landlockBinary, [...grants, "--", "/usr/bin/truncate", "-s", "0", outside], {
+        timeout: 2_000,
+      });
+      return false;
+    } catch {
+      return (await readFile(outside, "utf8")) === "must-remain";
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 }
 
 /**
@@ -48,55 +127,178 @@ export interface BubblewrapCapabilities {
  * unprivileged user namespaces fails here, not mid-session.
  */
 export async function detectBubblewrap(): Promise<BubblewrapCapabilities> {
+  if (!existsSync("/usr/bin/prlimit")) {
+    return { available: false, reason: "/usr/bin/prlimit is required for resource limits" };
+  }
   let version: string;
   try {
-    const { stdout } = await run("bwrap", ["--version"]);
+    const { stdout } = await run("bwrap", ["--version"], { timeout: 2_000 });
     version = stdout.trim();
   } catch {
     return { available: false, reason: "bwrap binary not found" };
   }
+  let seccompPolicyPath: string;
   try {
-    await run("bwrap", [
-      "--die-with-parent",
-      "--unshare-all",
-      "--ro-bind",
-      "/",
-      "/",
-      "--dev",
-      "/dev",
-      "--proc",
-      "/proc",
-      "--tmpfs",
-      "/tmp",
-      "true",
-    ]);
+    seccompPolicyPath = ensureSeccompFilterFile();
+    await run(
+      "/bin/sh",
+      [
+        "-c",
+        SECCOMP_WRAPPER,
+        "axl-seccomp",
+        seccompPolicyPath,
+        "bwrap",
+        "--seccomp",
+        String(SECCOMP_FD),
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+        "--unshare-user",
+        "--disable-userns",
+        "--cap-drop",
+        "ALL",
+        "--ro-bind",
+        "/",
+        "/",
+        "--dev",
+        "/dev",
+        "--proc",
+        "/proc",
+        "--tmpfs",
+        "/tmp",
+        "true",
+      ],
+      { timeout: 2_000 },
+    );
   } catch (error) {
     return {
       available: false,
       version,
-      reason: `namespace probe failed: ${error instanceof Error ? error.message.split("\n")[0] : "unknown"}`,
+      reason: `native confinement probe failed: ${error instanceof Error ? error.message.split("\n")[0] : "unknown"}`,
     };
   }
-  return { available: true, version };
+  const landlockLauncher = launcherPath();
+  const landlock = probeLandlock(landlockLauncher);
+  if (landlock === "unusable") {
+    return {
+      available: false,
+      version,
+      landlock,
+      landlockLauncher,
+      reason: "Landlock launcher is missing or the kernel cannot enforce Landlock",
+    };
+  }
+  const landlockFilesystemComplete = await probeLandlockFilesystem(landlockLauncher);
+  if (!landlockFilesystemComplete) {
+    return {
+      available: false,
+      version,
+      landlock,
+      landlockFilesystemComplete,
+      landlockLauncher,
+      seccompPolicyPath,
+      reason: "Landlock does not mediate every filesystem operation required by Axl",
+    };
+  }
+  return {
+    available: true,
+    version,
+    landlock,
+    landlockFilesystemComplete,
+    landlockLauncher,
+    seccompPolicyPath,
+  };
+}
+
+function withSeccomp(argv: readonly string[], seccompPolicyPath: string): readonly string[] {
+  return [
+    "/bin/sh",
+    "-c",
+    SECCOMP_WRAPPER,
+    "axl-seccomp",
+    seccompPolicyPath,
+    argv[0] as string,
+    "--seccomp",
+    String(SECCOMP_FD),
+    ...argv.slice(1),
+  ];
+}
+
+function landlockGrantArguments(policy: WorkspacePolicy): readonly string[] {
+  const readOnly = [
+    ...SYSTEM_READ_ROOTS.filter((path) => existsSync(path)),
+    ...policy.readableRoots
+      .map((path) => resolve(path))
+      .filter((path) => path !== resolve(policy.workspace)),
+  ];
+  const readWrite = [
+    resolve(policy.workspace),
+    "/tmp",
+    ...DEVICE_GRANTS.filter((path) => existsSync(path)),
+  ];
+  return grantArgs({ readOnly: [...new Set(readOnly)], readWrite: [...new Set(readWrite)] });
+}
+
+function appendReadableRootMounts(argv: string[], policy: WorkspacePolicy): void {
+  const workspace = resolve(policy.workspace);
+  for (const root of policy.readableRoots) {
+    const canonical = resolve(root);
+    if (canonical !== workspace) argv.push("--ro-bind", canonical, canonical);
+  }
+}
+
+function appendLandlockCommand(
+  argv: string[],
+  policy: WorkspacePolicy,
+  command: string,
+  args: readonly string[],
+  landlockBinary: string,
+  longLived: boolean,
+): void {
+  argv.push("--dir", "/run/axl", "--ro-bind", landlockBinary, LANDLOCK_MOUNT_PATH);
+  const limits = [
+    `--as=${NATIVE_LIMITS.addressSpaceBytes}`,
+    `--nproc=${NATIVE_LIMITS.processes}`,
+    `--nofile=${NATIVE_LIMITS.openFiles}`,
+    `--fsize=${NATIVE_LIMITS.fileSizeBytes}`,
+    ...(longLived ? [] : [`--cpu=${NATIVE_LIMITS.cpuSeconds}`]),
+  ];
+  argv.push(
+    LANDLOCK_MOUNT_PATH,
+    ...landlockGrantArguments(policy),
+    "--",
+    "/usr/bin/prlimit",
+    ...limits,
+    "--",
+    command,
+    ...args,
+  );
 }
 
 /**
  * Builds the Bubblewrap argv for one command: full namespace isolation, a
  * read-only view of the host, writable workspace, protected paths masked with
- * empty tmpfs, no network, and a cleared environment with a short allowlist.
+ * empty tmpfs, no network, a Landlock read allowlist, and a cleared environment.
  */
 export function buildBubblewrapArgv(
   policy: WorkspacePolicy,
   command: string,
   cwd: string,
   env: Readonly<Record<string, string | undefined>> = process.env,
+  landlockBinary = launcherPath(),
+  seccompPolicyPath = ensureSeccompFilterFile(),
 ): readonly string[] {
   const home = resolve(env.HOME ?? homedir());
   if (home === "/") throw new SandboxUnavailableError("cannot mask a root home directory");
   const argv: string[] = [
     "bwrap",
     "--die-with-parent",
+    "--new-session",
     "--unshare-all",
+    "--unshare-user",
+    "--disable-userns",
+    "--cap-drop",
+    "ALL",
     "--ro-bind",
     "/",
     "/",
@@ -107,11 +309,14 @@ export function buildBubblewrapArgv(
     "--tmpfs",
     "/tmp",
     "--tmpfs",
+    "/run",
+    "--tmpfs",
     home,
     "--bind",
     policy.workspace,
     policy.workspace,
   ];
+  appendReadableRootMounts(argv, policy);
   for (const protectedPath of policy.protectedPaths) {
     argv.push("--tmpfs", protectedPath);
   }
@@ -120,8 +325,9 @@ export function buildBubblewrapArgv(
     const separator = pair.indexOf("=");
     argv.push("--setenv", pair.slice(0, separator), pair.slice(separator + 1));
   }
-  argv.push("--chdir", cwd, "bash", "-c", command);
-  return argv;
+  argv.push("--chdir", cwd);
+  appendLandlockCommand(argv, policy, "bash", ["-c", command], landlockBinary, false);
+  return withSeccomp(argv, seccompPolicyPath);
 }
 
 export interface SandboxedProcess {
@@ -129,6 +335,7 @@ export interface SandboxedProcess {
   readonly args: readonly string[];
   readonly cwd: string;
   readonly env: Readonly<Record<string, string>>;
+  readonly cleanup?: () => Promise<void>;
 }
 
 /** Builds a direct argv wrapper for a long-lived extension process. */
@@ -138,12 +345,19 @@ export function buildBubblewrapProcess(
   args: readonly string[],
   cwd: string,
   env: Readonly<Record<string, string | undefined>> = process.env,
+  landlockBinary = launcherPath(),
+  seccompPolicyPath = ensureSeccompFilterFile(),
 ): SandboxedProcess {
   const home = resolve(env.HOME ?? homedir());
   if (home === "/") throw new SandboxUnavailableError("cannot mask a root home directory");
   const argv = [
     "--die-with-parent",
+    "--new-session",
     "--unshare-all",
+    "--unshare-user",
+    "--disable-userns",
+    "--cap-drop",
+    "ALL",
     "--ro-bind",
     "/",
     "/",
@@ -154,14 +368,22 @@ export function buildBubblewrapProcess(
     "--tmpfs",
     "/tmp",
     "--tmpfs",
+    "/run",
+    "--tmpfs",
     home,
     "--bind",
     policy.workspace,
     policy.workspace,
   ];
+  appendReadableRootMounts(argv, policy);
   for (const protectedPath of policy.protectedPaths) argv.push("--tmpfs", protectedPath);
-  argv.push("--chdir", cwd, command, ...args);
-  return { command: "bwrap", args: argv, cwd, env: definedEnvironment(env) };
+  argv.push("--chdir", cwd);
+  appendLandlockCommand(argv, policy, command, args, landlockBinary, true);
+  const [wrappedCommand, ...wrappedArgs] = withSeccomp(["bwrap", ...argv], seccompPolicyPath) as [
+    string,
+    ...string[],
+  ];
+  return { command: wrappedCommand, args: wrappedArgs, cwd, env: definedEnvironment(env) };
 }
 
 export interface BubblewrapShellOptions extends Omit<ShellToolOptions, "wrapCommand"> {
@@ -178,11 +400,19 @@ export function makeBubblewrapShellTool(options: BubblewrapShellOptions): Kernel
   if (!options.capabilities.available) {
     throw new SandboxUnavailableError(options.capabilities.reason ?? "unknown");
   }
-  const { policy, capabilities: _capabilities, ...shellOptions } = options;
+  const { policy, capabilities, ...shellOptions } = options;
   return makeShellTool({
     ...shellOptions,
     policy,
-    wrapCommand: (command, cwd) => buildBubblewrapArgv(policy, command, cwd),
+    wrapCommand: (command, cwd) =>
+      buildBubblewrapArgv(
+        policy,
+        command,
+        cwd,
+        process.env,
+        capabilities.landlockLauncher ?? launcherPath(),
+        capabilities.seccompPolicyPath ?? ensureSeccompFilterFile(),
+      ),
   });
 }
 
@@ -193,6 +423,24 @@ export function bubblewrapConfiguredPayload(
   return {
     provider: "bubblewrap",
     enforced: capabilities.available,
-    controls: capabilities.available ? [...BUBBLEWRAP_CONTROLS] : [],
+    controls: capabilities.available
+      ? [
+          ...BUBBLEWRAP_CONTROLS,
+          ...(capabilities.landlock === undefined
+            ? []
+            : [`process.landlock.${capabilities.landlock}`]),
+        ]
+      : [],
+    ...(capabilities.available
+      ? {
+          details: {
+            bubblewrapVersion: capabilities.version ?? "unknown",
+            landlock: capabilities.landlock ?? "unknown",
+            landlockFilesystemComplete: capabilities.landlockFilesystemComplete ?? false,
+            seccompPolicy: SECCOMP_POLICY_VERSION,
+            limits: { ...NATIVE_LIMITS },
+          },
+        }
+      : {}),
   };
 }

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -5,3 +5,4 @@ export * from "./bubblewrap.ts";
 export * from "./environment.ts";
 export * from "./platform.ts";
 export * from "./seatbelt.ts";
+export * from "./seccomp.ts";

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from "./bubblewrap.ts";
 export * from "./environment.ts";
+export * from "./oci.ts";
 export * from "./platform.ts";
 export * from "./seatbelt.ts";
 export * from "./seccomp.ts";

--- a/packages/sandbox/src/oci.ts
+++ b/packages/sandbox/src/oci.ts
@@ -1,0 +1,666 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { readFileSync, realpathSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+
+import {
+  makeShellTool,
+  type KernelTool,
+  type ShellToolOptions,
+  type WorkspacePolicy,
+} from "@axl/kernel";
+import type { EventPayloadMap } from "@axl/protocol";
+
+import { allowlistedEnvironmentRecord, definedEnvironment } from "./environment.ts";
+import { type SandboxedProcess, SandboxUnavailableError } from "./bubblewrap.ts";
+
+const run = promisify(execFile);
+const ENGINE_PROBE_TIMEOUT_MS = 5_000;
+const ENGINE_OPERATION_TIMEOUT_MS = 15_000;
+const DIGEST_SEPARATOR = "@sha256:";
+const CLEANUP_WRAPPER = `
+engine=$1
+name=$2
+shift 2
+cleanup() {
+  "$engine" rm -f "$name" >/dev/null 2>&1 || true
+}
+trap 'cleanup; exit 143' HUP INT TERM
+"$@"
+status=$?
+cleanup
+if "$engine" container inspect "$name" >/dev/null 2>&1; then
+  echo "axl: failed to remove OCI container $name" >&2
+  exit 125
+fi
+exit "$status"
+`.trim();
+
+export type OciEngine = "podman" | "docker";
+
+export interface OciCapabilities {
+  readonly engine: OciEngine;
+  readonly available: boolean;
+  readonly version?: string;
+  readonly rootless?: boolean;
+  readonly vmIsolation?: boolean;
+  readonly seccomp?: boolean;
+  readonly cgroupsV2?: boolean;
+  readonly resourceLimitsVerified?: boolean;
+  readonly runtime?: string;
+  readonly reason?: string;
+}
+
+export interface OciLimits {
+  readonly cpus: number;
+  readonly memoryBytes: number;
+  readonly pids: number;
+  readonly temporaryBytes: number;
+  readonly openFiles: number;
+  readonly fileSizeBytes: number;
+}
+
+export const DEFAULT_OCI_LIMITS: OciLimits = {
+  cpus: 2,
+  memoryBytes: 4 * 1024 * 1024 * 1024,
+  pids: 256,
+  temporaryBytes: 512 * 1024 * 1024,
+  openFiles: 1024,
+  fileSizeBytes: 256 * 1024 * 1024,
+};
+
+export const OCI_CONTROLS: readonly string[] = [
+  "filesystem.read-allowlist",
+  "filesystem.readonly-root",
+  "filesystem.workspace-writes",
+  "filesystem.masked-protected-paths",
+  "network.none",
+  "environment.cleared",
+  "process.namespaces",
+  "process.capabilities-dropped",
+  "process.no-new-privileges",
+  "process.seccomp",
+  "resources.cgroups-v2",
+  "resources.rlimits",
+  "runtime.oci",
+  "runtime.entrypoint-overridden",
+  "termination.remove-on-exit",
+  "termination.verified",
+];
+
+function firstLine(error: unknown): string {
+  return error instanceof Error ? (error.message.split("\n")[0] ?? error.message) : "unknown error";
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function bool(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+async function readEngineInfo(
+  engine: OciEngine,
+  env: Readonly<Record<string, string | undefined>>,
+): Promise<Record<string, unknown>> {
+  const args =
+    engine === "podman" ? ["info", "--format", "json"] : ["info", "--format", "{{json .}}"];
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const result = await run(engine, args, {
+        env: definedEnvironment(env),
+        maxBuffer: 4 * 1024 * 1024,
+        timeout: ENGINE_PROBE_TIMEOUT_MS,
+      });
+      return object(JSON.parse(result.stdout));
+    } catch (error) {
+      lastError = error;
+      if (attempt < 2) await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+    }
+  }
+  throw lastError;
+}
+
+/** Probes the actual engine daemon, privilege mode, seccomp, cgroups, and runtime. */
+export async function detectOciEngine(
+  engine: OciEngine,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<OciCapabilities> {
+  let version: string;
+  try {
+    const result = await run(engine, ["--version"], {
+      env: definedEnvironment(env),
+      timeout: ENGINE_PROBE_TIMEOUT_MS,
+    });
+    version = result.stdout.trim();
+  } catch {
+    return { engine, available: false, reason: `${engine} executable is missing or unusable` };
+  }
+
+  try {
+    const info = await readEngineInfo(engine, env);
+    if (engine === "podman") {
+      const host = object(info.host);
+      const security = object(host.security);
+      const runtime = object(host.ociRuntime);
+      const rootless = bool(security.rootless) ?? false;
+      if (!rootless) {
+        return { engine, available: false, version, rootless, reason: "Podman is not rootless" };
+      }
+      const seccomp = bool(security.seccompEnabled) ?? false;
+      const cgroupsV2 = host.cgroupVersion === "v2";
+      if (!seccomp || !cgroupsV2) {
+        return {
+          engine,
+          available: false,
+          version,
+          rootless,
+          seccomp,
+          cgroupsV2,
+          reason: `Podman lacks required ${!seccomp ? "seccomp" : "cgroups v2"} enforcement`,
+        };
+      }
+      const runtimeName = text(runtime.name);
+      return {
+        engine,
+        available: true,
+        version,
+        rootless,
+        seccomp,
+        cgroupsV2,
+        resourceLimitsVerified: false,
+        ...(runtimeName === undefined ? {} : { runtime: runtimeName }),
+      };
+    }
+
+    const securityOptions = Array.isArray(info.SecurityOptions)
+      ? info.SecurityOptions.filter((item): item is string => typeof item === "string")
+      : [];
+    const operatingSystem = text(info.OperatingSystem) ?? "";
+    const rootless = securityOptions.some((option) => option.includes("rootless"));
+    const vmIsolation = /docker desktop/i.test(operatingSystem);
+    const seccomp = securityOptions.some((option) => option.includes("seccomp"));
+    const cgroupsV2 = String(info.CgroupVersion) === "2";
+    if (!seccomp || !cgroupsV2) {
+      return {
+        engine,
+        available: false,
+        version,
+        rootless,
+        vmIsolation,
+        seccomp,
+        cgroupsV2,
+        reason: `Docker lacks required ${!seccomp ? "seccomp" : "cgroups v2"} enforcement`,
+      };
+    }
+    const runtimeName = text(info.DefaultRuntime);
+    return {
+      engine,
+      available: true,
+      version,
+      rootless,
+      vmIsolation,
+      seccomp,
+      cgroupsV2,
+      resourceLimitsVerified: false,
+      ...(runtimeName === undefined ? {} : { runtime: runtimeName }),
+    };
+  } catch (error) {
+    return {
+      engine,
+      available: false,
+      version,
+      reason: `${engine} daemon probe failed: ${firstLine(error)}`,
+    };
+  }
+}
+
+function lowercaseHexDigest(value: string): boolean {
+  if (value.length !== 64) return false;
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (!((code >= 48 && code <= 57) || (code >= 97 && code <= 102))) return false;
+  }
+  return true;
+}
+
+export function assertDigestPinnedImage(image: string): void {
+  const separator = image.lastIndexOf(DIGEST_SEPARATOR);
+  const name = separator < 1 ? "" : image.slice(0, separator);
+  const digest = separator < 0 ? "" : image.slice(separator + DIGEST_SEPARATOR.length);
+  const validName =
+    name.length > 0 &&
+    !name.includes("@") &&
+    ![...name].some((character) => character.trim() === "");
+  if (!validName || !lowercaseHexDigest(digest)) {
+    throw new SandboxUnavailableError(
+      `OCI image must be pinned to a sha256 digest, received ${JSON.stringify(image)}`,
+    );
+  }
+}
+
+function canonicalExistingPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch (error) {
+    throw new SandboxUnavailableError(
+      `OCI mount path ${resolve(path)} cannot be canonicalized: ${firstLine(error)}`,
+    );
+  }
+}
+
+function containerWorkingDirectory(policy: WorkspacePolicy, cwd: string): string {
+  const workspace = canonicalExistingPath(validateMountPath(resolve(policy.workspace)));
+  const requested = canonicalExistingPath(validateMountPath(resolve(cwd)));
+  const fromWorkspace = relative(workspace, requested);
+  if (fromWorkspace === "" || (!fromWorkspace.startsWith(`..${sep}`) && fromWorkspace !== "..")) {
+    return requested;
+  }
+  throw new SandboxUnavailableError(`working directory ${requested} is outside ${workspace}`);
+}
+
+function validateMountPath(path: string): string {
+  if (path.includes(",") || path.includes("\0")) {
+    throw new SandboxUnavailableError(`OCI mount path contains an unsupported character: ${path}`);
+  }
+  return path;
+}
+
+function mountPath(path: string): string {
+  return canonicalExistingPath(validateMountPath(resolve(path)));
+}
+
+function decodeMountPath(path: string): string {
+  return path.replace(/\\([0-7]{3})/g, (_match, octal: string) =>
+    String.fromCharCode(Number.parseInt(octal, 8)),
+  );
+}
+
+function rejectNestedMounts(roots: readonly string[]): void {
+  let source: string;
+  try {
+    source = readFileSync("/proc/self/mountinfo", "utf8");
+  } catch (error) {
+    throw new SandboxUnavailableError(`cannot inspect host mount topology: ${firstLine(error)}`);
+  }
+  const mountPoints = source
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => decodeMountPath(line.split(" ")[4] ?? ""));
+  for (const root of roots) {
+    const prefix = `${root}${sep}`;
+    const nested = mountPoints.find((mount) => mount.startsWith(prefix));
+    if (nested !== undefined) {
+      throw new SandboxUnavailableError(
+        `OCI bind root ${root} contains nested host mount ${nested}`,
+      );
+    }
+  }
+}
+
+function mountArguments(engine: OciEngine, policy: WorkspacePolicy): string[] {
+  const workspace = mountPath(policy.workspace);
+  const readableRoots = policy.readableRoots.map(mountPath);
+  rejectNestedMounts([workspace, ...readableRoots]);
+  const args = ["--mount", `type=bind,src=${workspace},dst=${workspace}`];
+  for (const canonical of readableRoots) {
+    if (canonical === workspace) continue;
+    args.push("--mount", `type=bind,src=${canonical},dst=${canonical},readonly`);
+  }
+  for (const path of policy.protectedPaths) {
+    args.push("--tmpfs", `${validateMountPath(resolve(path))}:rw,nosuid,nodev,noexec,size=1m`);
+  }
+  if (engine === "podman") args.push("--userns=keep-id");
+  return args;
+}
+
+const ENGINE_ENVIRONMENT = [
+  "PATH",
+  "HOME",
+  "XDG_RUNTIME_DIR",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "DOCKER_HOST",
+  "CONTAINER_HOST",
+] as const;
+
+function engineEnvironment(
+  source: Readonly<Record<string, string | undefined>>,
+): Record<string, string> {
+  return Object.fromEntries(
+    ENGINE_ENVIRONMENT.flatMap((name) => {
+      const value = source[name];
+      return value === undefined ? [] : [[name, value] as const];
+    }),
+  );
+}
+
+export interface OciRunOptions {
+  readonly engine: OciEngine;
+  readonly image: string;
+  readonly policy: WorkspacePolicy;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly includeConfiguredEnvironment?: boolean;
+  readonly limits?: OciLimits;
+  readonly name?: string;
+}
+
+/** Builds a fail-closed OCI invocation with a fixed cleanup trap and positional arguments. */
+export function buildOciRunArgv(options: OciRunOptions): readonly string[] {
+  assertDigestPinnedImage(options.image);
+  const limits = options.limits ?? DEFAULT_OCI_LIMITS;
+  const name = options.name ?? `axl-${randomUUID()}`;
+  const engineArgv = [
+    options.engine,
+    "run",
+    "--rm",
+    "--name",
+    name,
+    "--pull=never",
+    "--stop-timeout=1",
+    "--network=none",
+    "--ipc=private",
+    "--hostname=axl-sandbox",
+    "--init",
+    "--read-only",
+    "--cap-drop=ALL",
+    "--security-opt=no-new-privileges",
+    "--pids-limit",
+    String(limits.pids),
+    "--memory",
+    String(limits.memoryBytes),
+    "--cpus",
+    String(limits.cpus),
+    "--tmpfs",
+    `/tmp:rw,nosuid,nodev,size=${limits.temporaryBytes}`,
+    "--ulimit",
+    `nofile=${limits.openFiles}:${limits.openFiles}`,
+    "--ulimit",
+    `fsize=${limits.fileSizeBytes}:${limits.fileSizeBytes}`,
+    "--user",
+    `${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}`,
+    "--workdir",
+    containerWorkingDirectory(options.policy, options.cwd),
+    ...mountArguments(options.engine, options.policy),
+    "--entrypoint",
+    options.command,
+  ];
+  const environment = options.includeConfiguredEnvironment
+    ? definedEnvironment(options.env ?? process.env)
+    : allowlistedEnvironmentRecord(options.env ?? process.env);
+  for (const [name, value] of Object.entries(environment)) {
+    if (name === "HOME" || name === "PATH" || name === "SHELL" || name === "USER") continue;
+    engineArgv.push("--env", options.includeConfiguredEnvironment ? name : `${name}=${value}`);
+  }
+  engineArgv.push(options.image, ...options.args);
+  return ["/bin/sh", "-c", CLEANUP_WRAPPER, "axl-oci-cleanup", options.engine, name, ...engineArgv];
+}
+
+function missingContainer(error: unknown): boolean {
+  const stderr =
+    typeof error === "object" && error !== null && "stderr" in error
+      ? String((error as { stderr?: unknown }).stderr ?? "")
+      : "";
+  return /no such (container|object)|not found/i.test(stderr);
+}
+
+async function containerExists(
+  engine: OciEngine,
+  name: string,
+  env: Readonly<Record<string, string | undefined>>,
+): Promise<boolean> {
+  try {
+    await run(engine, ["container", "inspect", name], {
+      env: definedEnvironment(env),
+      maxBuffer: 1024 * 1024,
+      timeout: ENGINE_OPERATION_TIMEOUT_MS,
+    });
+    return true;
+  } catch (error) {
+    if (missingContainer(error)) return false;
+    throw error;
+  }
+}
+
+/** Idempotently removes a container, then asks the engine to prove it is absent. */
+export async function removeOciContainer(
+  engine: OciEngine,
+  name: string,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<void> {
+  if (!(await containerExists(engine, name, env))) return;
+  await run(engine, ["rm", "-f", name], {
+    env: definedEnvironment(env),
+    maxBuffer: 1024 * 1024,
+    timeout: ENGINE_OPERATION_TIMEOUT_MS,
+  });
+  if (await containerExists(engine, name, env)) {
+    throw new Error(`${engine} did not remove OCI container ${name}`);
+  }
+}
+
+export interface OciPlatformOptions {
+  readonly capabilities: OciCapabilities;
+  readonly image: string;
+  readonly engineEnv?: Readonly<Record<string, string | undefined>>;
+  readonly limits?: OciLimits;
+}
+
+export interface OciShellOptions extends Omit<ShellToolOptions, "wrapCommand"> {
+  readonly policy: WorkspacePolicy;
+}
+
+/** Creates a PlatformSandbox-compatible OCI execution backend. */
+export function createOciPlatformExecution(options: OciPlatformOptions): {
+  readonly provider: OciEngine;
+  readonly available: boolean;
+  readonly reason?: string;
+  makeShellTool(input: OciShellOptions): KernelTool;
+  wrapProcess(input: {
+    readonly policy: WorkspacePolicy;
+    readonly command: string;
+    readonly args: readonly string[];
+    readonly cwd: string;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+  }): SandboxedProcess;
+  configuredPayload(): EventPayloadMap["sandbox.configured"];
+} {
+  const { capabilities, image, limits } = options;
+  const engineEnv = engineEnvironment(options.engineEnv ?? process.env);
+  assertDigestPinnedImage(image);
+  if (!capabilities.available) {
+    throw new SandboxUnavailableError(capabilities.reason ?? `${capabilities.engine} unavailable`);
+  }
+  if (capabilities.resourceLimitsVerified !== true) {
+    throw new SandboxUnavailableError(
+      `${capabilities.engine} cgroup resource limits have not been functionally verified`,
+    );
+  }
+  const common = (input: {
+    readonly policy: WorkspacePolicy;
+    readonly command: string;
+    readonly args: readonly string[];
+    readonly cwd: string;
+    readonly env?: Readonly<Record<string, string | undefined>>;
+    readonly includeConfiguredEnvironment?: boolean;
+  }): { readonly argv: readonly string[]; readonly cleanup: () => Promise<void> } => {
+    const name = `axl-${randomUUID()}`;
+    const containerEnv = input.env ?? process.env;
+    let cleanupPromise: Promise<void> | undefined;
+    return {
+      argv: buildOciRunArgv({
+        engine: capabilities.engine,
+        image,
+        policy: input.policy,
+        command: input.command,
+        args: input.args,
+        cwd: input.cwd,
+        env: containerEnv,
+        ...(input.includeConfiguredEnvironment === undefined
+          ? {}
+          : { includeConfiguredEnvironment: input.includeConfiguredEnvironment }),
+        ...(limits === undefined ? {} : { limits }),
+        name,
+      }),
+      cleanup: () => {
+        cleanupPromise ??= removeOciContainer(capabilities.engine, name, engineEnv);
+        return cleanupPromise;
+      },
+    };
+  };
+  return {
+    provider: capabilities.engine,
+    available: true,
+    makeShellTool: ({ policy, ...shellOptions }) =>
+      makeShellTool({
+        ...shellOptions,
+        policy,
+        wrapCommand: (command, cwd) =>
+          common({ policy, command: "bash", args: ["-c", command], cwd }),
+      }),
+    wrapProcess: (input) => {
+      const invocation = common({ ...input, includeConfiguredEnvironment: true });
+      const [command, ...args] = invocation.argv as [string, ...string[]];
+      return {
+        command,
+        args,
+        cwd: input.cwd,
+        env: { ...engineEnv, ...definedEnvironment(input.env ?? {}) },
+        cleanup: invocation.cleanup,
+      };
+    },
+    configuredPayload: () => ({
+      provider: capabilities.engine,
+      enforced: true,
+      controls: [
+        ...OCI_CONTROLS,
+        capabilities.rootless ? "runtime.rootless" : "runtime.rootful",
+        ...(capabilities.vmIsolation ? ["runtime.vm-isolation"] : []),
+        ...(capabilities.runtime === undefined ? [] : [`runtime.oci.${capabilities.runtime}`]),
+      ],
+      details: {
+        engineVersion: capabilities.version ?? "unknown",
+        image,
+        rootless: capabilities.rootless ?? false,
+        vmIsolation: capabilities.vmIsolation ?? false,
+        seccomp: capabilities.seccomp ?? false,
+        cgroupsV2: capabilities.cgroupsV2 ?? false,
+        resourceLimitsVerified: capabilities.resourceLimitsVerified ?? false,
+        runtime: capabilities.runtime ?? "unknown",
+        limits: {
+          cpus: (limits ?? DEFAULT_OCI_LIMITS).cpus,
+          memoryBytes: (limits ?? DEFAULT_OCI_LIMITS).memoryBytes,
+          pids: (limits ?? DEFAULT_OCI_LIMITS).pids,
+          temporaryBytes: (limits ?? DEFAULT_OCI_LIMITS).temporaryBytes,
+          openFiles: (limits ?? DEFAULT_OCI_LIMITS).openFiles,
+          fileSizeBytes: (limits ?? DEFAULT_OCI_LIMITS).fileSizeBytes,
+        },
+      },
+    }),
+  };
+}
+
+async function verifyOciResourceLimits(
+  engine: OciEngine,
+  image: string,
+  env: Readonly<Record<string, string | undefined>>,
+): Promise<void> {
+  const name = `axl-probe-${randomUUID()}`;
+  try {
+    const result = await run(
+      engine,
+      [
+        "run",
+        "--rm",
+        "--name",
+        name,
+        "--pull=never",
+        "--network=none",
+        "--read-only",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        "--memory",
+        "67108864",
+        "--cpus",
+        "0.5",
+        "--pids-limit",
+        "32",
+        "--entrypoint",
+        "bash",
+        image,
+        "-c",
+        "printf 'memory=%s\\n' \"$(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo missing)\"; printf 'pids=%s\\n' \"$(cat /sys/fs/cgroup/pids.max 2>/dev/null || echo missing)\"; printf 'cpu=%s\\n' \"$(cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo missing)\"",
+      ],
+      {
+        env: definedEnvironment(env),
+        maxBuffer: 1024 * 1024,
+        timeout: ENGINE_OPERATION_TIMEOUT_MS,
+      },
+    );
+    if (
+      !/memory=67108864(?:\r?\n)/.test(result.stdout) ||
+      !/pids=32(?:\r?\n)/.test(result.stdout) ||
+      !/cpu=50000 100000(?:\r?\n|$)/.test(result.stdout)
+    ) {
+      throw new Error(
+        `reported cgroup values do not match the requested limits: ${result.stdout.trim()}`,
+      );
+    }
+  } finally {
+    await removeOciContainer(engine, name, env);
+  }
+}
+
+/** Requires a functional engine, local digest-pinned image, and enforced limits. */
+export async function prepareOciPlatformExecution(input: {
+  readonly engine: OciEngine;
+  readonly image: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly limits?: OciLimits;
+}): Promise<ReturnType<typeof createOciPlatformExecution>> {
+  assertDigestPinnedImage(input.image);
+  const env = input.env ?? process.env;
+  const capabilities = await detectOciEngine(input.engine, env);
+  if (!capabilities.available) {
+    throw new SandboxUnavailableError(capabilities.reason ?? `${input.engine} unavailable`);
+  }
+  try {
+    await run(input.engine, ["image", "inspect", input.image], {
+      env: definedEnvironment(env),
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: ENGINE_OPERATION_TIMEOUT_MS,
+    });
+  } catch (error) {
+    throw new SandboxUnavailableError(
+      `${input.engine} image ${input.image} is not available locally: ${firstLine(error)}`,
+    );
+  }
+  try {
+    await verifyOciResourceLimits(input.engine, input.image, env);
+  } catch (error) {
+    throw new SandboxUnavailableError(
+      `${input.engine} could not prove cgroup resource limits: ${firstLine(error)}`,
+    );
+  }
+  return createOciPlatformExecution({
+    capabilities: { ...capabilities, resourceLimitsVerified: true },
+    image: input.image,
+    engineEnv: env,
+    ...(input.limits === undefined ? {} : { limits: input.limits }),
+  });
+}

--- a/packages/sandbox/src/platform.ts
+++ b/packages/sandbox/src/platform.ts
@@ -31,7 +31,7 @@ export interface PlatformShellOptions extends Omit<ShellToolOptions, "wrapComman
 
 /** The host's sandbox provider: detection result plus the tool factory. */
 export interface PlatformSandbox {
-  readonly provider: "bubblewrap" | "seatbelt" | "none";
+  readonly provider: "bubblewrap" | "seatbelt" | "podman" | "docker" | "none";
   readonly available: boolean;
   readonly reason?: string;
   /** Throws SandboxUnavailableError when the provider is unavailable. */
@@ -77,7 +77,15 @@ export async function detectPlatformSandbox(): Promise<PlatformSandbox> {
       ...(capabilities.reason === undefined ? {} : { reason: capabilities.reason }),
       makeShellTool: (options) => makeBubblewrapShellTool({ ...options, capabilities }),
       wrapProcess: ({ policy, command, args, cwd, env }) =>
-        buildBubblewrapProcess(policy, command, args, cwd, env),
+        buildBubblewrapProcess(
+          policy,
+          command,
+          args,
+          cwd,
+          env,
+          capabilities.landlockLauncher,
+          capabilities.seccompPolicyPath,
+        ),
       configuredPayload: () => bubblewrapConfiguredPayload(capabilities),
     };
   }

--- a/packages/sandbox/src/seccomp.ts
+++ b/packages/sandbox/src/seccomp.ts
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const SECCOMP_POLICY_VERSION = "axl-linux-deny-v1";
+
+const BPF_LD_W_ABS = 0x20;
+const BPF_JMP_JEQ_K = 0x15;
+const BPF_RET_K = 0x06;
+const SECCOMP_RET_KILL_PROCESS = 0x80000000;
+const SECCOMP_RET_ERRNO = 0x00050000;
+const SECCOMP_RET_ALLOW = 0x7fff0000;
+const EPERM = 1;
+
+const ARCHITECTURES = {
+  x64: {
+    audit: 0xc000003e,
+    denied: [
+      101, // ptrace
+      155, // pivot_root
+      165, // mount
+      166, // umount2
+      167, // swapon
+      168, // swapoff
+      169, // reboot
+      175, // init_module
+      176, // delete_module
+      246, // kexec_load
+      248, // add_key
+      249, // request_key
+      250, // keyctl
+      272, // unshare
+      298, // perf_event_open
+      304, // open_by_handle_at
+      308, // setns
+      313, // finit_module
+      321, // bpf
+      323, // userfaultfd
+      425, // io_uring_setup
+      426, // io_uring_enter
+      427, // io_uring_register
+    ],
+  },
+  arm64: {
+    audit: 0xc00000b7,
+    denied: [
+      39, // umount2
+      40, // mount
+      41, // pivot_root
+      97, // unshare
+      104, // kexec_load
+      105, // init_module
+      106, // delete_module
+      117, // ptrace
+      142, // reboot
+      217, // add_key
+      218, // request_key
+      219, // keyctl
+      224, // swapon
+      225, // swapoff
+      241, // perf_event_open
+      265, // open_by_handle_at
+      268, // setns
+      273, // finit_module
+      280, // bpf
+      282, // userfaultfd
+      425, // io_uring_setup
+      426, // io_uring_enter
+      427, // io_uring_register
+    ],
+  },
+} as const;
+
+interface Instruction {
+  readonly code: number;
+  readonly jt: number;
+  readonly jf: number;
+  readonly value: number;
+}
+
+function instruction(code: number, jt: number, jf: number, value: number): Instruction {
+  return { code, jt, jf, value };
+}
+
+/** Builds a classic BPF seccomp program for the current Linux architecture. */
+export function buildSeccompFilter(arch: NodeJS.Architecture = process.arch): Buffer {
+  if (arch !== "x64" && arch !== "arm64") {
+    throw new Error(`No ${SECCOMP_POLICY_VERSION} seccomp policy for architecture ${arch}`);
+  }
+  const policy = ARCHITECTURES[arch];
+  const instructions: Instruction[] = [
+    instruction(BPF_LD_W_ABS, 0, 0, 4), // seccomp_data.arch
+    instruction(BPF_JMP_JEQ_K, 1, 0, policy.audit),
+    instruction(BPF_RET_K, 0, 0, SECCOMP_RET_KILL_PROCESS),
+    instruction(BPF_LD_W_ABS, 0, 0, 0), // seccomp_data.nr
+  ];
+  for (const syscall of policy.denied) {
+    instructions.push(
+      instruction(BPF_JMP_JEQ_K, 0, 1, syscall),
+      instruction(BPF_RET_K, 0, 0, SECCOMP_RET_ERRNO | EPERM),
+    );
+  }
+  instructions.push(instruction(BPF_RET_K, 0, 0, SECCOMP_RET_ALLOW));
+
+  const output = Buffer.allocUnsafe(instructions.length * 8);
+  for (const [index, entry] of instructions.entries()) {
+    const offset = index * 8;
+    output.writeUInt16LE(entry.code, offset);
+    output.writeUInt8(entry.jt, offset + 2);
+    output.writeUInt8(entry.jf, offset + 3);
+    output.writeUInt32LE(entry.value >>> 0, offset + 4);
+  }
+  return output;
+}
+
+/** Writes the deterministic policy under a private per-user temporary directory. */
+export function ensureSeccompFilterFile(
+  arch: NodeJS.Architecture = process.arch,
+  directory = join(tmpdir(), `axl-${process.getuid?.() ?? "user"}`),
+): string {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const metadata = lstatSync(directory);
+  if (
+    !metadata.isDirectory() ||
+    (process.getuid !== undefined && metadata.uid !== process.getuid())
+  ) {
+    throw new Error(`Refusing untrusted seccomp directory ${directory}`);
+  }
+  chmodSync(directory, 0o700);
+  const path = join(directory, `${SECCOMP_POLICY_VERSION}-${arch}.bpf`);
+  const temporary = join(directory, `.${SECCOMP_POLICY_VERSION}-${randomUUID()}.tmp`);
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      temporary,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    fchmodSync(fd, 0o600);
+    writeFileSync(fd, buildSeccompFilter(arch));
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(temporary, path);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(temporary, { force: true });
+  }
+  return path;
+}

--- a/packages/sandbox/test/bubblewrap.test.ts
+++ b/packages/sandbox/test/bubblewrap.test.ts
@@ -59,11 +59,21 @@ test("builds the confinement argv: namespaces, masks, cleared environment", () =
     readableRoots: ["/repo"],
     protectedPaths: ["/home/user/.axl"],
   };
-  const argv = buildBubblewrapArgv(policy, "echo hi", "/repo", {
-    PATH: "/usr/bin",
-    HOME: "/home/user",
-  });
-  assert.equal(argv[0], "bwrap");
+  const argv = buildBubblewrapArgv(
+    policy,
+    "echo hi",
+    "/repo",
+    {
+      PATH: "/usr/bin",
+      HOME: "/home/user",
+    },
+    "/test/landlock-run",
+    "/test/seccomp.bpf",
+  );
+  assert.equal(argv[0], "/bin/sh");
+  assert.equal(argv.includes("bwrap"), true);
+  assert.equal(argv.includes("--seccomp"), true);
+  assert.equal(argv.includes("/test/seccomp.bpf"), true);
   assert.equal(argv.includes("--unshare-all"), true);
   assert.equal(argv.includes("--die-with-parent"), true);
   assert.equal(argv.includes("--clearenv"), true);
@@ -79,24 +89,39 @@ test("builds the confinement argv: namespaces, masks, cleared environment", () =
   ]);
   const maskIndex = argv.indexOf("--tmpfs", argv.indexOf("--bind"));
   assert.deepEqual(argv.slice(maskIndex, maskIndex + 2), ["--tmpfs", "/home/user/.axl"]);
-  assert.deepEqual(argv.slice(-5), ["--chdir", "/repo", "bash", "-c", "echo hi"]);
+  assert.equal(argv.includes("/run/axl/landlock-run"), true);
+  assert.equal(argv.includes("/test/landlock-run"), true);
+  assert.deepEqual(argv.slice(-3), ["bash", "-c", "echo hi"]);
   // No environment value leaks without an allowlist entry.
   assert.equal(argv.includes("AZURE_OPENAI_API_KEY"), false);
 });
 
-test("wraps long-lived extension processes without a shell", () => {
+test("wraps long-lived processes with fixed seccomp arguments and no interpolation", () => {
   const policy: WorkspacePolicy = {
     workspace: "/repo",
     readableRoots: ["/repo"],
     protectedPaths: ["/home/user/.axl"],
   };
-  const process = buildBubblewrapProcess(policy, "node", ["server.mjs"], "/repo", {
-    PATH: "/usr/bin",
-    HOME: "/home/user",
-    MCP_TOKEN: "secret",
-  });
-  assert.equal(process.command, "bwrap");
-  assert.deepEqual(process.args.slice(-4), ["--chdir", "/repo", "node", "server.mjs"]);
+  const process = buildBubblewrapProcess(
+    policy,
+    "node",
+    ["server.mjs"],
+    "/repo",
+    {
+      PATH: "/usr/bin",
+      HOME: "/home/user",
+      MCP_TOKEN: "secret",
+    },
+    "/test/landlock-run",
+    "/test/seccomp.bpf",
+  );
+  assert.equal(process.command, "/bin/sh");
+  assert.equal(process.args.includes("bwrap"), true);
+  assert.equal(process.args.includes("--seccomp"), true);
+  assert.equal(process.args.includes("/test/seccomp.bpf"), true);
+  assert.equal(process.args.includes("/run/axl/landlock-run"), true);
+  assert.equal(process.args.includes("/test/landlock-run"), true);
+  assert.deepEqual(process.args.slice(-2), ["node", "server.mjs"]);
   const homeMask = process.args.findIndex(
     (part, index) => part === "--tmpfs" && process.args[index + 1] === "/home/user",
   );
@@ -159,11 +184,18 @@ test("unsafe execution is explicit, unconfined, and reported as unenforced", asy
   });
 });
 
+test("functional detection requires complete Landlock filesystem mediation", integration, () => {
+  assert.equal(capabilities.landlockFilesystemComplete, true);
+  assert.equal(capabilities.seccompPolicyPath?.endsWith(".bpf"), true);
+});
+
 test("the configured payload reports provider and controls honestly", () => {
   const enforced = bubblewrapConfiguredPayload({ available: true, version: "x" });
   assert.equal(enforced.provider, "bubblewrap");
   assert.equal(enforced.enforced, true);
   assert.deepEqual(enforced.controls, [...BUBBLEWRAP_CONTROLS]);
+  assert.equal(enforced.details?.seccompPolicy, "axl-linux-deny-v1");
+  assert.equal(enforced.details?.landlock, "unknown");
   const missing = bubblewrapConfiguredPayload({ available: false, reason: "nope" });
   assert.deepEqual(missing, { provider: "bubblewrap", enforced: false, controls: [] });
 });
@@ -174,6 +206,25 @@ test("sandboxed commands run and workspace writes work", integration, async (con
   assert.equal(result.isError, false);
   assert.match(text(result), /made/);
   assert.equal(await readFile(join(workspace, "made.txt"), "utf8"), "made\n");
+});
+
+test("Landlock denies shell reads outside explicit roots", integration, async (context) => {
+  const root = await mkdtemp(join("/var/tmp", "axl-landlock-"));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  const workspace = join(root, "workspace");
+  const outside = join(root, "outside.txt");
+  await mkdir(workspace);
+  await writeFile(outside, "host-private-data\n");
+  const tool = makeBubblewrapShellTool({
+    cwd: workspace,
+    overflowDirectory: join(workspace, ".output"),
+    policy: { workspace, readableRoots: [workspace], protectedPaths: [] },
+    capabilities,
+  });
+  const denied = await tool.execute({ command: `cat ${outside}` }, noSignal);
+  assert.equal(denied.isError, true);
+  assert.equal(text(denied).includes("host-private-data"), false);
+  assert.match(text(denied), /Permission denied/);
 });
 
 test(
@@ -222,22 +273,48 @@ test(
     const root = await mkdtemp(join(homedir(), ".axl-bwrap-test-"));
     context.after(() => rm(root, { recursive: true, force: true }));
     const workspace = join(root, "workspace");
+    const readable = join(root, "readable");
     const outside = join(root, "outside.txt");
     await mkdir(workspace);
+    await mkdir(readable);
     await writeFile(join(workspace, "inside.txt"), "inside\n");
+    await writeFile(join(readable, "allowed.txt"), "allowed\n");
     await writeFile(outside, "private-home-data\n");
     const tool = makeBubblewrapShellTool({
       cwd: workspace,
       overflowDirectory: join(workspace, ".output"),
-      policy: { workspace, readableRoots: [workspace], protectedPaths: [] },
+      policy: { workspace, readableRoots: [workspace, readable], protectedPaths: [] },
       capabilities,
     });
     const result = await tool.execute(
-      { command: `cat inside.txt; cat ${outside} 2>/dev/null || true` },
+      {
+        command: `cat inside.txt; cat ${join(readable, "allowed.txt")}; cat ${outside} 2>/dev/null || true`,
+      },
       noSignal,
     );
     assert.match(text(result), /inside/);
+    assert.match(text(result), /allowed/);
     assert.equal(text(result).includes("private-home-data"), false);
+  },
+);
+
+test(
+  "seccomp, no-new-privileges, capabilities, and rlimits are active",
+  integration,
+  async (context) => {
+    const { tool } = await makeLayout(context);
+    const result = await tool.execute(
+      {
+        command:
+          "printf 'nofile=%s\\n' \"$(ulimit -n)\"; grep -E '^(NoNewPrivs|Seccomp|CapEff):' /proc/self/status",
+      },
+      noSignal,
+    );
+    assert.equal(result.isError, false);
+    assert.match(text(result), /nofile=1024/);
+    assert.match(text(result), /NoNewPrivs:\s+1/);
+    assert.match(text(result), /Seccomp:\s+2/);
+    assert.match(text(result), /CapEff:\s+0+/);
   },
 );
 

--- a/packages/sandbox/test/oci.test.ts
+++ b/packages/sandbox/test/oci.test.ts
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+import { promisify } from "node:util";
+
+import type { WorkspacePolicy } from "@axl/kernel";
+
+import {
+  assertDigestPinnedImage,
+  buildOciRunArgv,
+  createOciPlatformExecution,
+  detectOciEngine,
+  prepareOciPlatformExecution,
+  SandboxUnavailableError,
+} from "../src/index.ts";
+
+const run = promisify(execFile);
+const image =
+  "docker.io/library/bash@sha256:3bee76a96d86d5d2d5efc7c1c570e5a7c95db22348a26944e0e546fa174e3324";
+const noSignal = new AbortController().signal;
+
+function output(result: { content: readonly { type: string; text?: string }[] }): string {
+  return result.content[0]?.type === "text" ? (result.content[0].text ?? "") : "";
+}
+
+async function layout(context: TestContext): Promise<{
+  root: string;
+  workspace: string;
+  readable: string;
+  policy: WorkspacePolicy;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "axl-oci-"));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  const workspace = join(root, "workspace");
+  const readable = join(root, "readable");
+  const protectedPath = join(root, "protected");
+  await mkdir(workspace);
+  await mkdir(readable);
+  await mkdir(protectedPath);
+  await writeFile(join(readable, "reference.txt"), "reference\n");
+  await writeFile(join(protectedPath, "secret.txt"), "host-secret\n");
+  return {
+    root,
+    workspace,
+    readable,
+    policy: {
+      workspace,
+      readableRoots: [workspace, readable],
+      protectedPaths: [protectedPath],
+    },
+  };
+}
+
+test("requires a digest-pinned OCI image", () => {
+  assert.doesNotThrow(() => assertDigestPinnedImage(image));
+  assert.throws(
+    () => assertDigestPinnedImage("docker.io/library/bash:5.2.37"),
+    SandboxUnavailableError,
+  );
+});
+
+test("reports the selected image, privilege mode, runtime, and limits", () => {
+  const sandbox = createOciPlatformExecution({
+    image,
+    capabilities: {
+      engine: "podman",
+      available: true,
+      version: "podman version test",
+      rootless: true,
+      seccomp: true,
+      cgroupsV2: true,
+      resourceLimitsVerified: true,
+      runtime: "crun",
+    },
+  });
+  const payload = sandbox.configuredPayload();
+  assert.equal(payload.provider, "podman");
+  assert.equal(payload.enforced, true);
+  assert.equal(payload.controls.includes("runtime.rootless"), true);
+  assert.equal(payload.details?.image, image);
+  assert.equal(payload.details?.runtime, "crun");
+  assert.equal(typeof payload.details?.limits, "object");
+
+  const workspace = process.cwd();
+  const wrapped = sandbox.wrapProcess({
+    policy: { workspace, readableRoots: [workspace], protectedPaths: [] },
+    command: "node",
+    args: ["server.mjs"],
+    cwd: workspace,
+    env: { PATH: "/usr/bin", HOME: "/home/user", MCP_TOKEN: "secret-value" },
+  });
+  assert.equal(
+    wrapped.args.some((part) => part.includes("secret-value")),
+    false,
+  );
+  assert.equal(wrapped.args.includes("MCP_TOKEN"), true);
+  assert.equal(wrapped.env.MCP_TOKEN, "secret-value");
+});
+
+test("rejects ambiguous mount paths", () => {
+  assert.throws(
+    () =>
+      buildOciRunArgv({
+        engine: "podman",
+        image,
+        policy: {
+          workspace: "/repo,other",
+          readableRoots: ["/repo,other"],
+          protectedPaths: [],
+        },
+        command: "true",
+        args: [],
+        cwd: "/repo,other",
+      }),
+    /unsupported character/,
+  );
+});
+
+test("builds equivalent hardened Podman and Docker invocations", () => {
+  const workspace = process.cwd();
+  const policy: WorkspacePolicy = {
+    workspace,
+    readableRoots: [workspace, "/etc/passwd"],
+    protectedPaths: [join(workspace, ".axl")],
+  };
+  for (const engine of ["podman", "docker"] as const) {
+    const argv = buildOciRunArgv({
+      engine,
+      image,
+      policy,
+      command: "bash",
+      args: ["-c", "echo hi"],
+      cwd: workspace,
+      env: { PATH: "/host/bin", HOME: "/host/home", LANG: "C.UTF-8", TOKEN: "secret" },
+      name: `axl-test-${engine}`,
+    });
+    assert.equal(argv[0], "/bin/sh");
+    assert.equal(argv.includes(engine), true);
+    assert.equal(argv.includes("--pull=never"), true);
+    assert.equal(argv.includes("--network=none"), true);
+    assert.equal(argv.includes("--read-only"), true);
+    assert.equal(argv.includes("--cap-drop=ALL"), true);
+    assert.equal(argv.includes("--security-opt=no-new-privileges"), true);
+    assert.equal(argv.includes("--pids-limit"), true);
+    assert.equal(argv.includes("--memory"), true);
+    assert.equal(argv.includes("--cpus"), true);
+    assert.equal(argv.includes(`type=bind,src=${workspace},dst=${workspace}`), true);
+    assert.equal(argv.includes("type=bind,src=/etc/passwd,dst=/etc/passwd,readonly"), true);
+    assert.equal(argv.includes(`${join(workspace, ".axl")}:rw,nosuid,nodev,noexec,size=1m`), true);
+    assert.equal(argv.includes("LANG=C.UTF-8"), true);
+    assert.equal(
+      argv.some((part) => part.includes("secret")),
+      false,
+    );
+    assert.equal(
+      argv.some((part) => part.includes("/host/home")),
+      false,
+    );
+    assert.equal(argv.includes("--entrypoint"), true);
+    assert.deepEqual(argv.slice(-3), [image, "-c", "echo hi"]);
+    assert.equal(argv.includes("--userns=keep-id"), engine === "podman");
+  }
+});
+
+for (const engine of ["podman", "docker"] as const) {
+  const capabilities = await detectOciEngine(engine);
+  let backendReady = false;
+  let unavailableReason = capabilities.reason;
+  if (capabilities.available) {
+    try {
+      await prepareOciPlatformExecution({ engine, image });
+      backendReady = true;
+    } catch (error) {
+      unavailableReason = error instanceof Error ? error.message : String(error);
+    }
+  }
+  const integration = {
+    skip: backendReady
+      ? false
+      : `${engine} unavailable for integration tests: ${unavailableReason ?? "unknown"}`,
+  };
+
+  test(`${engine}: reports real engine security capabilities`, integration, () => {
+    assert.equal(capabilities.available, true);
+    assert.equal(capabilities.seccomp, true);
+    assert.equal(capabilities.cgroupsV2, true);
+    if (engine === "podman") assert.equal(capabilities.rootless, true);
+  });
+
+  test(`${engine}: confines execution and removes the container`, integration, async (context) => {
+    const { root, workspace, readable, policy } = await layout(context);
+    const sandbox = await prepareOciPlatformExecution({ engine, image });
+    const tool = sandbox.makeShellTool({
+      cwd: workspace,
+      overflowDirectory: join(workspace, ".output"),
+      policy,
+    });
+    const result = await tool.execute(
+      {
+        command: `echo container > made.txt; cat made.txt; cat ${readable}/reference.txt; (echo changed > ${readable}/reference.txt) 2>/dev/null || true; cat ${root}/protected/secret.txt 2>/dev/null || true; cat /etc/shadow 2>/dev/null || true; printf 'nofile=%s\\n' "$(ulimit -n)"; grep -E '^(NoNewPrivs|Seccomp|CapEff):' /proc/self/status; printf 'memory='; cat /sys/fs/cgroup/memory.max; printf 'pids='; cat /sys/fs/cgroup/pids.max; printf 'cpu='; cat /sys/fs/cgroup/cpu.max; (exec 3<>/dev/tcp/1.1.1.1/80 && echo CONNECTED) 2>/dev/null || true`,
+      },
+      noSignal,
+    );
+    assert.equal(result.isError, false);
+    assert.match(output(result), /container/);
+    assert.match(output(result), /reference/);
+    assert.equal(output(result).includes("CONNECTED"), false);
+    assert.equal(output(result).includes("host-secret"), false);
+    assert.equal(output(result).includes("root:"), false);
+    assert.match(output(result), /nofile=1024/);
+    assert.match(output(result), /NoNewPrivs:\s+1/);
+    assert.match(output(result), /Seccomp:\s+2/);
+    assert.match(output(result), /CapEff:\s+0+/);
+    assert.match(output(result), /memory=4294967296/);
+    assert.match(output(result), /pids=256/);
+    assert.match(output(result), /cpu=200000 100000/);
+    assert.equal(await readFile(join(workspace, "made.txt"), "utf8"), "container\n");
+    assert.equal(await readFile(join(readable, "reference.txt"), "utf8"), "reference\n");
+    assert.equal(output(result).includes(root), false);
+    const listed = await run(engine, ["ps", "-aq", "--filter", "name=axl-"]);
+    assert.equal(listed.stdout.trim(), "");
+  });
+
+  test(
+    `${engine}: cancellation and timeout remove running containers`,
+    integration,
+    async (context) => {
+      const { workspace, policy } = await layout(context);
+      const sandbox = await prepareOciPlatformExecution({ engine, image });
+      const tool = sandbox.makeShellTool({
+        cwd: workspace,
+        overflowDirectory: join(workspace, ".output"),
+        policy,
+      });
+      const controller = new AbortController();
+      const executing = tool.execute({ command: "sleep 30" }, controller.signal);
+      setTimeout(() => controller.abort(), 250);
+      const aborted = await executing;
+      assert.equal(aborted.isError, true);
+      assert.match(output(aborted), /aborted/);
+
+      const timedOut = await tool.execute({ command: "sleep 30", timeoutMs: 250 }, noSignal);
+      assert.equal(timedOut.isError, true);
+      assert.match(output(timedOut), /timed out/);
+
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        const listed = await run(engine, ["ps", "-aq", "--filter", "name=axl-"]);
+        if (listed.stdout.trim() === "") return;
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+      }
+      assert.fail(`${engine} left an axl container behind after cancellation`);
+    },
+  );
+}

--- a/packages/sandbox/test/seccomp.test.ts
+++ b/packages/sandbox/test/seccomp.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+
+import {
+  buildSeccompFilter,
+  ensureSeccompFilterFile,
+  SECCOMP_POLICY_VERSION,
+} from "../src/index.ts";
+
+test("builds a deterministic versioned seccomp filter", () => {
+  const first = buildSeccompFilter("x64");
+  const second = buildSeccompFilter("x64");
+  assert.equal(first.equals(second), true);
+  assert.equal(first.byteLength > 8, true);
+  assert.equal(first.byteLength % 8, 0);
+  assert.equal(SECCOMP_POLICY_VERSION, "axl-linux-deny-v1");
+  assert.throws(() => buildSeccompFilter("ia32"), /No .* seccomp policy/);
+});
+
+test("writes the filter to a private deterministic path", async () => {
+  const path = ensureSeccompFilterFile("x64");
+  const metadata = await stat(path);
+  assert.equal(metadata.mode & 0o777, 0o600);
+  assert.equal((await readFile(path)).equals(buildSeccompFilter("x64")), true);
+});
+
+test("atomically replaces a profile symlink without touching its target", async (context: TestContext) => {
+  const root = await mkdtemp(join(tmpdir(), "axl-seccomp-test-"));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  const directory = join(root, "private");
+  await mkdir(directory, { mode: 0o700 });
+  const victim = join(root, "victim");
+  await writeFile(victim, "unchanged");
+  const profile = join(directory, `${SECCOMP_POLICY_VERSION}-x64.bpf`);
+  await symlink(victim, profile);
+  assert.equal(ensureSeccompFilterFile("x64", directory), profile);
+  assert.equal((await readFile(profile)).equals(buildSeccompFilter("x64")), true);
+  assert.equal(await readFile(victim, "utf8"), "unchanged");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@axl/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@deepseek-ai/node-addon-landlock-run':
+        specifier: 0.1.1
+        version: 0.1.1
 
   packages/tui:
     dependencies:
@@ -226,6 +229,22 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@deepseek-ai/node-addon-landlock-run-linux-arm64@0.1.1':
+    resolution: {integrity: sha512-lYY2RbcPW4rGRM5hVJbrXlvLqyBxeJBjBqvt+QTHTU+GtfUVVjTODKa4e3CRwMQoCEpOjoARdQBHbN7HvE72WQ==}
+    engines: {node: '>=20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@deepseek-ai/node-addon-landlock-run-linux-x64@0.1.1':
+    resolution: {integrity: sha512-OHAzPW2Coe/iYobAJAAA8CeVrBoKV4BnNHsgwvXwOfishxkUVSWSvdyxrZPiwYRXutpIGVrSo9zV3WOQy2euBA==}
+    engines: {node: '>=20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@deepseek-ai/node-addon-landlock-run@0.1.1':
+    resolution: {integrity: sha512-aHGhlQJEutfobKM/4K59SERbT7RmQdD2oMKzD8Bne/Ps7TeT8AweCN+dpdfuxQhMNbFcJMymrgPnID0WYQ30Tw==}
+    engines: {node: '>=20'}
 
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
@@ -819,6 +838,17 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.3.5':
     optional: true
+
+  '@deepseek-ai/node-addon-landlock-run-linux-arm64@0.1.1':
+    optional: true
+
+  '@deepseek-ai/node-addon-landlock-run-linux-x64@0.1.1':
+    optional: true
+
+  '@deepseek-ai/node-addon-landlock-run@0.1.1':
+    optionalDependencies:
+      '@deepseek-ai/node-addon-landlock-run-linux-arm64': 0.1.1
+      '@deepseek-ai/node-addon-landlock-run-linux-x64': 0.1.1
 
   '@esbuild/aix-ppc64@0.28.2':
     optional: true


### PR DESCRIPTION
## Purpose

Complete the local Linux isolation boundary and add digest-pinned local OCI execution through rootless Podman and Docker. This establishes the tested local execution substrate needed before remote sandbox workers.

## Approach

- Add the pinned `@deepseek-ai/node-addon-landlock-run` 0.1.1 launcher after source, package, binary, integrity, and license review.
- Combine Bubblewrap with functional Landlock filesystem probing, a versioned seccomp denylist, dropped capabilities, private runtime mounts, and rlimits.
- Add a shared Podman and Docker backend with read-only roots, explicit mounts, no network, no implicit pulls, seccomp, cgroups v2 limits, digest-pinned images, and verified cleanup.
- Functionally verify OCI CPU, memory, and PID limits before accepting an engine and image.
- Reject nested host mounts, ambiguous mount paths, mutable tags, backend mismatches, image mismatches, and unavailable enforcement.
- Add `axl doctor` plus `--sandbox podman|docker --image <digest>`.
- Keep OCI daemon state separate by engine and full image digest.
- Carry backend cleanup through shell and stdio MCP lifecycles.

Docker may be rootful. That distinction is recorded in `sandbox.configured.details`; rootless Podman remains the preferred engine.

## How was this tested?

- `pnpm install --frozen-lockfile`: passed.
- `pnpm check`: passed with 397 tests passing and 2 macOS-only Seatbelt tests skipped.
- `pnpm audit --audit-level high`: no known vulnerabilities.
- `reuse lint`: compliant.
- `git diff --check`: passed.
- Native Bubblewrap, Landlock, seccomp, rlimit, path, cancellation, and cleanup stress suite: 100 consecutive iterations passed after fixing an atomic seccomp-profile write race found by the stress run.
- Rootless Podman post-restart stress suite: 5 consecutive iterations passed, followed by another complete rerun.
- Docker OCI stress suite: 10 consecutive iterations passed.
- Runtime, CLI, and MCP lifecycle stress suite: 30 consecutive iterations passed.
- Real rootless Podman 4.9.3 with crun verified seccomp, cgroups v2 CPU/memory/PID limits, mounts, no network, cancellation, timeout, and no leftover containers.
- Real Docker 29.1.3 with runc verified the same conformance contract and no leftover containers.
- `axl daemon --sandbox podman|docker` startup and daemon identity negotiation passed against the pinned test image.
- Seatbelt runtime behavior could not be exercised on this Linux host.

## Learning

Engine capability claims are insufficient by themselves. Podman initially reported cgroups v2 while silently failing to apply limits without WSL systemd delegation. Axl now runs an image-level cgroup probe and fails closed unless the requested values are observed inside the container.

## Checklist

- [x] I reviewed the complete diff.
- [x] I added or updated the smallest relevant tests for behavior changes.
- [x] I ran formatting, lint, type-check, test, boundary, generated-file, audit, and license checks.
- [x] Every new file has SPDX metadata, directly or through `REUSE.toml`.
- [x] Every commit has a matching DCO `Signed-off-by` trailer.
- [x] User-visible changes update `CHANGELOG.md`.
- [x] No TUI files or UI behavior changed, so screenshots are not applicable.

## AI assistance

- [x] Generative AI materially assisted this change. Tool and model/version: Pi coding agent with `gpt-5.6-sol` through `azure-openai-responses`.
- [x] I manually reviewed, understood, and tested the generated work.