### PR TITLE
fix(kernel): serialize file mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This file records notable user-facing changes.
 
 ### Changed
 
+- File edits and writes targeting the same canonical path now serialize in call order, and stale exact-text edits fail before writing.
 - Local provider, tool, extension, and sandbox assembly now lives outside the terminal client, so clients remain replaceable projections over the daemon protocol.
 - File tools now require explicit readable roots, and the default runtime limits them to the workspace.
 - The canonical command tool is named `bash`; historical `shell` calls remain replayable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1329,7 +1329,7 @@ The mobile app is a remote-control client over the same daemon protocol, in the 
 
 Capabilities:
 
-- List, open, and start sessions on cloud workers or reachable daemons
+- List and open sessions, request new sessions on cloud workers, and attach to reachable daemons. The mobile app never starts a daemon process on the device; the remote control plane allocates the sandboxed worker and starts its daemon.
 - Live conversation view with tool, diff, and terminal cards
 - Reply to and steer a running session
 - Answer permission requests from the phone

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2448,6 +2448,6 @@ Complete these dogfood fixes before continuing Phase 5:
 2. Build the local BM25 capability index and log the three-or-fewer records disclosed for each user turn.
 3. Replace the generic MCP gateway with selected provider-native tool schemas and frozen per-turn dispatch bindings.
 4. Add the bearer-token and basic-auth credential broker before using credentialed third-party processes in dogfood sessions.
-5. Add hash-anchored reads and edits with stale-snapshot rejection.
+5. Serialize `edit` and `write` operations by canonical file path, re-read inside the queue, and reject stale exact-text edits before writing.
 6. Add bounded parallel tool execution with deterministic call/result ordering and explicit concurrency policy.
 7. Stop and verify these paths before returning to web access or compaction.

--- a/docs/architecture/client-boundaries.md
+++ b/docs/architecture/client-boundaries.md
@@ -22,6 +22,23 @@ This document defines which behavior is shared, which code remains platform-spec
 
 The daemon is the sole authority for session state and effects. The SDK contains reusable client behavior, but it is not an alternate authority. SDK projections and caches are disposable views of daemon-owned canonical events.
 
+## Daemon launch and session placement
+
+A protocol client and a daemon process host are distinct roles. `packages/sdk` connects to a daemon but never launches one. A trusted process host may connect to an existing daemon or launch the daemon before handing an SDK client to its presentation layer.
+
+| Consumer | Daemon launch owner |
+| --- | --- |
+| Terminal | `packages/cli` launches a local daemon; the TUI only uses the SDK client |
+| Local web | The planned `axl web` gateway host launches a local daemon; browser code never does |
+| Desktop | A trusted native, Tauri, or Electron main process may launch a local daemon; renderer code never does |
+| IDE | A trusted extension host may launch a local daemon; an embedded webview never does |
+| Headless | The command or automation runner may launch a local daemon |
+| Mobile or remote web | An authenticated remote control plane allocates a cloud worker or locates a reachable daemon; client code never launches a daemon process on the device |
+
+With future cloud sandbox support, mobile and remote web clients may request creation of a session on a cloud placement. This is a daemon or control-plane operation, not local process authority. The cloud worker starts the sandboxed daemon, and the client attaches through the authenticated protocol. Mobile devices and browsers never run the agent loop, tools, or workspace authority.
+
+A host that bundles a daemon and client still performs the normal wire-version handshake. An already-running daemon may survive a host upgrade, so an incompatible daemon fails loudly and requires an explicit lifecycle action. A host must not automatically replace a daemon while it owns active work.
+
 ## Consumer-only clients
 
 A presentation client may own:

--- a/packages/kernel/src/tools/edit.ts
+++ b/packages/kernel/src/tools/edit.ts
@@ -3,12 +3,11 @@
 
 import { randomUUID } from "node:crypto";
 import { readFile, rename, rm, stat, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
-
 import type { JsonObject } from "@axl/protocol";
 
-import { assertWriteAllowed, type WorkspacePolicy } from "../path-policy.ts";
+import type { WorkspacePolicy } from "../path-policy.ts";
 import type { KernelTool, ToolExecutionResult } from "../tools.ts";
+import { withFileMutationQueue } from "./file-mutation-queue.ts";
 import {
   optionalBoolean,
   rejectUnknownFields,
@@ -55,10 +54,9 @@ export function makeEditTool(options: EditToolOptions): KernelTool {
       required: ["path", "oldText", "newText"],
       additionalProperties: false,
     },
-    async execute(input: JsonObject): Promise<ToolExecutionResult> {
+    async execute(input: JsonObject, signal: AbortSignal): Promise<ToolExecutionResult> {
       rejectUnknownFields(input, "edit", ["path", "oldText", "newText", "replaceAll"]);
-      let path = resolve(options.cwd, requiredString(input, "edit", "path"));
-      if (options.policy !== undefined) path = await assertWriteAllowed(options.policy, path);
+      const requestedPath = requiredString(input, "edit", "path");
       const oldText = requiredString(input, "edit", "oldText");
       const newText = input.newText;
       if (typeof newText !== "string") {
@@ -69,48 +67,61 @@ export function makeEditTool(options: EditToolOptions): KernelTool {
       }
       const replaceAll = optionalBoolean(input, "edit", "replaceAll") ?? false;
 
-      let content: string;
-      try {
-        content = await readFile(path, "utf8");
-      } catch (error) {
-        throw new ToolInputError(
-          `edit: cannot read ${path}: ${(error as NodeJS.ErrnoException).code ?? "unknown error"}`,
-        );
-      }
+      return withFileMutationQueue(
+        options.cwd,
+        requestedPath,
+        options.policy,
+        async (path): Promise<ToolExecutionResult> => {
+          signal.throwIfAborted();
+          let content: string;
+          try {
+            content = await readFile(path, { encoding: "utf8", signal });
+          } catch (error) {
+            if (signal.aborted) throw signal.reason;
+            throw new ToolInputError(
+              `edit: cannot read ${path}: ${(error as NodeJS.ErrnoException).code ?? "unknown error"}`,
+            );
+          }
 
-      const occurrences = countOccurrences(content, oldText);
-      if (occurrences === 0) {
-        throw new ToolInputError(`edit: oldText not found in ${path}`);
-      }
-      if (occurrences > 1 && !replaceAll) {
-        throw new ToolInputError(
-          `edit: oldText occurs ${occurrences} times in ${path}; make it unique or set replaceAll`,
-        );
-      }
+          const occurrences = countOccurrences(content, oldText);
+          if (occurrences === 0) {
+            throw new ToolInputError(
+              `edit: Target changed or no longer matches. Read the file again and retry. Path: ${path}`,
+            );
+          }
+          if (occurrences > 1 && !replaceAll) {
+            throw new ToolInputError(
+              `edit: oldText occurs ${occurrences} times in ${path}; make it unique or set replaceAll`,
+            );
+          }
 
-      const updated = replaceAll
-        ? content.split(oldText).join(newText)
-        : content.replace(oldText, newText);
-      const temporary = `${path}.${randomUUID()}.axl-tmp`;
-      try {
-        const mode = (await stat(path)).mode & 0o777;
-        await writeFile(temporary, updated, { encoding: "utf8", mode });
-        await rename(temporary, path);
-      } finally {
-        await rm(temporary, { force: true });
-      }
+          const updated = replaceAll
+            ? content.split(oldText).join(newText)
+            : content.replace(oldText, newText);
+          const temporary = `${path}.${randomUUID()}.axl-tmp`;
+          try {
+            const mode = (await stat(path)).mode & 0o777;
+            signal.throwIfAborted();
+            await writeFile(temporary, updated, { encoding: "utf8", mode, signal });
+            signal.throwIfAborted();
+            await rename(temporary, path);
+          } finally {
+            await rm(temporary, { force: true });
+          }
 
-      const replacements = replaceAll ? occurrences : 1;
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Replaced ${replacements} occurrence${replacements === 1 ? "" : "s"} in ${path}`,
-          },
-        ],
-        isError: false,
-        details: { path, replacements },
-      };
+          const replacements = replaceAll ? occurrences : 1;
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Replaced ${replacements} occurrence${replacements === 1 ? "" : "s"} in ${path}`,
+              },
+            ],
+            isError: false,
+            details: { path, replacements },
+          };
+        },
+      );
     },
   };
 }

--- a/packages/kernel/src/tools/file-mutation-queue.ts
+++ b/packages/kernel/src/tools/file-mutation-queue.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolve } from "node:path";
+
+import { assertWriteAllowed, canonicalizeForPolicy, type WorkspacePolicy } from "../path-policy.ts";
+
+interface QueueRegistration {
+  readonly path: string;
+  readonly previous: Promise<void>;
+  readonly tail: Promise<void>;
+  readonly release: () => void;
+}
+
+const queues = new Map<string, Promise<void>>();
+let registration = Promise.resolve();
+
+/** Serializes mutations to one canonical path while allowing different files to proceed. */
+export async function withFileMutationQueue<T>(
+  cwd: string,
+  requestedPath: string,
+  policy: WorkspacePolicy | undefined,
+  mutate: (path: string) => Promise<T>,
+): Promise<T> {
+  const registered = registration.then(async (): Promise<QueueRegistration> => {
+    const absolutePath = resolve(cwd, requestedPath);
+    const path =
+      policy === undefined
+        ? await canonicalizeForPolicy(absolutePath)
+        : await assertWriteAllowed(policy, absolutePath);
+    const previous = queues.get(path) ?? Promise.resolve();
+    let release = (): void => undefined;
+    const current = new Promise<void>((resolveCurrent) => {
+      release = resolveCurrent;
+    });
+    const tail = previous.then(() => current);
+    queues.set(path, tail);
+    return { path, previous, tail, release };
+  });
+  registration = registered.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  const entry = await registered;
+  await entry.previous;
+  try {
+    return await mutate(entry.path);
+  } finally {
+    entry.release();
+    if (queues.get(entry.path) === entry.tail) queues.delete(entry.path);
+  }
+}

--- a/packages/kernel/src/tools/write.ts
+++ b/packages/kernel/src/tools/write.ts
@@ -4,12 +4,13 @@
 
 import { randomUUID } from "node:crypto";
 import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 
 import type { JsonObject } from "@axl/protocol";
 
-import { assertWriteAllowed, type WorkspacePolicy } from "../path-policy.ts";
+import type { WorkspacePolicy } from "../path-policy.ts";
 import type { KernelTool, ToolExecutionResult } from "../tools.ts";
+import { withFileMutationQueue } from "./file-mutation-queue.ts";
 import { rejectUnknownFields, requiredString, ToolInputError } from "./validate.ts";
 
 export interface WriteToolOptions {
@@ -35,10 +36,9 @@ export function makeWriteTool(options: WriteToolOptions): KernelTool {
       required: ["path", "content"],
       additionalProperties: false,
     },
-    async execute(input: JsonObject): Promise<ToolExecutionResult> {
+    async execute(input: JsonObject, signal: AbortSignal): Promise<ToolExecutionResult> {
       rejectUnknownFields(input, "write", ["path", "content"]);
-      let path = resolve(options.cwd, requiredString(input, "write", "path"));
-      if (options.policy !== undefined) path = await assertWriteAllowed(options.policy, path);
+      const requestedPath = requiredString(input, "write", "path");
       const content = input.content;
       if (typeof content !== "string") throw new ToolInputError("write: content must be a string");
       const bytes = Buffer.byteLength(content, "utf8");
@@ -46,27 +46,38 @@ export function makeWriteTool(options: WriteToolOptions): KernelTool {
         throw new ToolInputError(`write: content is ${bytes} bytes; maximum is ${maxBytes}`);
       }
 
-      await mkdir(dirname(path), { recursive: true });
-      const temporary = `${path}.${randomUUID()}.axl-tmp`;
-      try {
-        const mode = await stat(path).then(
-          (value) => value.mode & 0o777,
-          (error: NodeJS.ErrnoException) => {
-            if (error.code === "ENOENT") return 0o644;
-            throw error;
-          },
-        );
-        await writeFile(temporary, content, { encoding: "utf8", mode, flag: "wx" });
-        await rename(temporary, path);
-      } finally {
-        await rm(temporary, { force: true });
-      }
+      return withFileMutationQueue(
+        options.cwd,
+        requestedPath,
+        options.policy,
+        async (path): Promise<ToolExecutionResult> => {
+          signal.throwIfAborted();
+          await mkdir(dirname(path), { recursive: true });
+          signal.throwIfAborted();
+          const temporary = `${path}.${randomUUID()}.axl-tmp`;
+          try {
+            const mode = await stat(path).then(
+              (value) => value.mode & 0o777,
+              (error: NodeJS.ErrnoException) => {
+                if (error.code === "ENOENT") return 0o644;
+                throw error;
+              },
+            );
+            signal.throwIfAborted();
+            await writeFile(temporary, content, { encoding: "utf8", mode, flag: "wx", signal });
+            signal.throwIfAborted();
+            await rename(temporary, path);
+          } finally {
+            await rm(temporary, { force: true });
+          }
 
-      return {
-        content: [{ type: "text", text: `Wrote ${bytes} bytes to ${path}` }],
-        isError: false,
-        details: { path, bytes },
-      };
+          return {
+            content: [{ type: "text", text: `Wrote ${bytes} bytes to ${path}` }],
+            isError: false,
+            details: { path, bytes },
+          };
+        },
+      );
     },
   };
 }

--- a/packages/kernel/test/canonical-tools.test.ts
+++ b/packages/kernel/test/canonical-tools.test.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { type TestContext } from "node:test";
@@ -253,7 +253,7 @@ test("edit rejects misses, ambiguity, and missing files before writing", async (
 
   await assert.rejects(
     edit.execute({ path: "code.ts", oldText: "y();", newText: "z();" }, noSignal),
-    /not found/,
+    /Target changed or no longer matches\. Read the file again and retry\./,
   );
   await assert.rejects(
     edit.execute({ path: "code.ts", oldText: "x();", newText: "z();" }, noSignal),
@@ -268,6 +268,97 @@ test("edit rejects misses, ambiguity, and missing files before writing", async (
     /identical/,
   );
   assert.equal(await readFile(path, "utf8"), original); // nothing was written
+});
+
+test("edit and write serialize same-file mutations in call order", async (context) => {
+  const cwd = await workspace(context);
+  const path = join(cwd, "code.ts");
+  const alias = join(cwd, "alias.ts");
+  await writeFile(path, "const a = 1;\nconst b = 1;\n");
+  await symlink(path, alias);
+  const firstEdit = makeEditTool({ cwd });
+  const secondEdit = makeEditTool({ cwd });
+  const write = makeWriteTool({ cwd });
+
+  await Promise.all([
+    firstEdit.execute(
+      { path: "code.ts", oldText: "const a = 1;", newText: "const a = 2;" },
+      noSignal,
+    ),
+    secondEdit.execute(
+      { path: "alias.ts", oldText: "const b = 1;", newText: "const b = 2;" },
+      noSignal,
+    ),
+  ]);
+  assert.equal(await readFile(path, "utf8"), "const a = 2;\nconst b = 2;\n");
+  assert.equal((await lstat(alias)).isSymbolicLink(), true);
+
+  const overlapping = await Promise.allSettled([
+    firstEdit.execute(
+      { path: "code.ts", oldText: "const a = 2;", newText: "const a = 3;" },
+      noSignal,
+    ),
+    secondEdit.execute(
+      { path: "alias.ts", oldText: "const a = 2;", newText: "const a = 4;" },
+      noSignal,
+    ),
+  ]);
+  assert.equal(overlapping[0]?.status, "fulfilled");
+  assert.equal(overlapping[1]?.status, "rejected");
+  assert.match(
+    String(overlapping[1]?.status === "rejected" ? overlapping[1].reason : ""),
+    /Target changed or no longer matches\. Read the file again and retry\./,
+  );
+  assert.equal(await readFile(path, "utf8"), "const a = 3;\nconst b = 2;\n");
+
+  await Promise.all([
+    firstEdit.execute(
+      { path: "code.ts", oldText: "const b = 2;", newText: "const b = 3;" },
+      noSignal,
+    ),
+    write.execute({ path: "alias.ts", content: "written last\n" }, noSignal),
+  ]);
+  assert.equal(await readFile(path, "utf8"), "written last\n");
+  assert.equal((await lstat(alias)).isSymbolicLink(), true);
+});
+
+test("file mutations on different paths remain independent", async (context) => {
+  const cwd = await workspace(context);
+  await Promise.all([
+    writeFile(join(cwd, "first.txt"), "first\n"),
+    writeFile(join(cwd, "second.txt"), "second\n"),
+  ]);
+  const first = makeEditTool({ cwd });
+  const second = makeEditTool({ cwd });
+
+  await Promise.all([
+    first.execute({ path: "first.txt", oldText: "first", newText: "one" }, noSignal),
+    second.execute({ path: "second.txt", oldText: "second", newText: "two" }, noSignal),
+  ]);
+  assert.equal(await readFile(join(cwd, "first.txt"), "utf8"), "one\n");
+  assert.equal(await readFile(join(cwd, "second.txt"), "utf8"), "two\n");
+});
+
+test("an aborted file mutation releases its queue", async (context) => {
+  const cwd = await workspace(context);
+  const path = join(cwd, "code.ts");
+  await writeFile(path, "const value = 1;\n");
+  const edit = makeEditTool({ cwd });
+  const aborted = new AbortController();
+  aborted.abort();
+
+  await assert.rejects(
+    edit.execute(
+      { path: "code.ts", oldText: "const value = 1;", newText: "const value = 2;" },
+      aborted.signal,
+    ),
+    (error) => error instanceof DOMException && error.name === "AbortError",
+  );
+  await edit.execute(
+    { path: "code.ts", oldText: "const value = 1;", newText: "const value = 3;" },
+    noSignal,
+  );
+  assert.equal(await readFile(path, "utf8"), "const value = 3;\n");
 });
 
 test("write creates directories, overwrites atomically, and enforces bounds", async (context) => {

--- a/packages/tui/test/app.test.ts
+++ b/packages/tui/test/app.test.ts
@@ -838,9 +838,11 @@ test("Ctrl+V paste, Shift+Enter, and searchable hotkeys behave", async (context)
   input.write("\x16");
   await until(() => text().includes("pasted second"), "clipboard insertion");
   input.write("\r");
-  await until(() => text().includes("│ pasted first"), "clipboard prompt submission");
+  await until(() => text().includes("↑1 ↓1"), "clipboard prompt reply");
+  assert.match(text(), /│ pasted first/);
   input.write("line one\x1b[13;2uline two\r");
-  await until(() => text().includes("line two"), "shift enter prompt submission");
+  await until(() => text().includes("↑2 ↓2"), "shift enter prompt reply");
+  assert.match(text(), /line two/);
   input.write("/hotkeys\r");
   await until(() => text().includes("Keyboard shortcuts"), "hotkeys dialog");
   assert.match(text(), /Ctrl\+A/);


### PR DESCRIPTION
## Purpose

Prevent concurrent canonical file tools from losing updates before bounded parallel tool execution is enabled. Keep exact replacement as the model-facing edit contract, remove the planned hash-anchored format from the roadmap, and clarify which trusted process host launches a daemon for each client distribution.

## Fixes

Fixes #18.

## Approach

- Replace the roadmap's hash-anchored edit item with canonical per-file serialization and stale exact-text rejection.
- Add one process-wide mutation queue shared by `edit` and `write`.
- Resolve aliases and symlinks to the same canonical queue key.
- Register mutations in invocation order, while allowing operations on different files to proceed independently.
- Re-read and validate exact target text only after an edit reaches the front of its queue.
- Keep temporary-file replacement atomic and keep the queue held until in-flight filesystem work settles.
- Preserve the existing edit schema. No fuzzy matcher, snapshot store, line hash, collision handling, or new edit format is added.
- Document that the CLI, local web gateway, desktop host, IDE host, headless runner, and remote control plane own daemon launch while presentation clients remain SDK-only projections.

## How was this tested?

- `node --test packages/kernel/test/canonical-tools.test.ts` passed, 18 tests.
- `node --test packages/kernel/test/canonical-tools.test.ts packages/kernel/test/path-policy.test.ts` passed, 23 tests.
- The focused concurrency tests passed 25 consecutive repetitions.
- The corrected hotkeys-flow test passed 25 consecutive repetitions after being changed to await canonical turn completion.
- `pnpm exec tsc --noEmit -p packages/kernel/tsconfig.json` passed.
- Focused Biome lint passed for all changed TypeScript files.
- `pnpm check` passed: formatting, lint, type checking, build, 505 tests with 497 passed and 8 environment-dependent sandbox tests skipped, package boundaries, and generated-file checks.
- `git diff --check` passed.
- Local `reuse lint` could not run because the `reuse` executable is not installed. The GitHub REUSE check passed, and the new TypeScript file has the repository's SPDX header.
- CI initially failed twice because the hotkeys-flow test submitted `/hotkeys` before the preceding asynchronous turn completed. The test now waits for canonical completion instead of an intermediate rendered prompt.
- One replacement CI run stalled in the combined check step and was cancelled. Its rerun completed successfully, and all required PR checks now pass.
- An initial focused Biome check reported one import-format difference; `pnpm exec biome format --write` corrected it before the successful checks above.
- `pnpm exec biome format ROADMAP.md` processed no files because Markdown is ignored by the repository's Biome configuration. `pnpm format:check` subsequently passed for all 238 configured files.

## Learning

Exact target text already acts as a regional content precondition. A canonical per-file mutation queue addresses the concrete lost-update risk without adding model-visible hash noise or another edit format. Hash-based edit results remain model-dependent and language-dependent, so Axl can reconsider them only if its own logged failures show a material exact-replacement problem.

## Checklist

- [ ] I reviewed the complete diff.
- [x] I added or updated the smallest relevant test for behavior changes.
- [x] I ran the relevant formatting, lint, type-check, test, boundary, and license checks.
- [x] Every new file has SPDX metadata, directly or through `REUSE.toml`.
- [x] Every commit has a matching DCO `Signed-off-by` trailer.
- [x] User-visible changes update `CHANGELOG.md`.
- [ ] UI changes include screenshots attached to the pull request, not committed to the repository.

## AI assistance

- [x] Generative AI materially assisted this change. Tool and model/version: pi coding agent; model/version was not exposed in the session environment.
- [ ] I manually reviewed, understood, and tested the generated work.
